### PR TITLE
[feat/#34] 카테고리 관리자 조회

### DIFF
--- a/app/api/admin/categories/route.ts
+++ b/app/api/admin/categories/route.ts
@@ -1,0 +1,30 @@
+import { GetAdmincategoryListQueryDto } from "./../../../../application/usecase/category/dto/GetAdminCategoryListQueryDto";
+import { GetAdminCategoryListUsecase } from "@/application/usecase/category/GetAdminCategoryListUsecase";
+import { CategoryRepository } from "@/domain/repositories/CategoryRepository";
+import { SbCategoryRepository } from "@/infra/repositories/supabase/SbCategoryRepository";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+    try {
+        const url = new URL(request.url);
+        const currentPageParam = url.searchParams.get("currentPage") || 1;
+
+        const categoryRepository: CategoryRepository =
+            new SbCategoryRepository();
+        const getAdminCategoryListUsecase = new GetAdminCategoryListUsecase(
+            categoryRepository,
+        );
+
+        const queryDto = new GetAdmincategoryListQueryDto(
+            Number(currentPageParam),
+        );
+        const categories = await getAdminCategoryListUsecase.execute(queryDto);
+
+        return NextResponse.json(categories);
+    } catch (error) {
+        return NextResponse.json(
+            { message: "카테고리 조회 실패" },
+            { status: 400 },
+        );
+    }
+}

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,5 +1,5 @@
 import { GetCategoryListQueryDto } from "@/application/usecase/category/dto/GetCategoryListQueryDto";
-import { GetCategories } from "@/application/usecase/category/GetCategoryListUsecase";
+import { GetCategoryListUseCase } from "@/application/usecase/category/GetCategoryListUsecase";
 import { CategoryRepository } from "@/domain/repositories/CategoryRepository";
 import { SbCategoryRepository } from "@/infra/repositories/supabase/SbCategoryRepository";
 import { NextResponse } from "next/server";
@@ -11,7 +11,9 @@ export async function GET(request: Request) {
 
         const categoryRepository: CategoryRepository =
             new SbCategoryRepository();
-        const getCategoryListUsecase = new GetCategories(categoryRepository);
+        const getCategoryListUsecase = new GetCategoryListUseCase(
+            categoryRepository,
+        );
 
         const queryDto = new GetCategoryListQueryDto(popularParam === "true");
         const categories = await getCategoryListUsecase.execute(queryDto);

--- a/application/usecase/category/GetAdminCategoryListUsecase.ts
+++ b/application/usecase/category/GetAdminCategoryListUsecase.ts
@@ -1,0 +1,45 @@
+import { CategoryRepository } from "@/domain/repositories/CategoryRepository";
+import { GetAdmincategoryListQueryDto } from "./dto/GetAdminCategoryListQueryDto";
+import { AdminCategoryListDto } from "./dto/AdminCategoryListDto";
+import { CategoryFilter } from "@/domain/repositories/filters/CategoryFilter";
+import { CategoryDto } from "./dto/CategoryDto";
+
+const PAGE_SIZE = 10;
+
+export class GetAdminCategoryListUsecase {
+    constructor(private categoryRepository: CategoryRepository) {}
+
+    async execute(
+        queryDto: GetAdmincategoryListQueryDto,
+    ): Promise<AdminCategoryListDto> {
+        try {
+            const currentPage = queryDto.currentPage || 1;
+            const popular = false;
+            const limit = PAGE_SIZE;
+            const offset = (currentPage - 1) * PAGE_SIZE;
+
+            const filter = new CategoryFilter(popular, offset, limit);
+
+            const categories: CategoryDto[] =
+                await this.categoryRepository.findAll(filter);
+            const totalCount = await this.categoryRepository.count();
+            const endPage = Math.ceil(totalCount / PAGE_SIZE);
+            const pages = Array.from({ length: endPage }, (_, i) => i + 1);
+
+            const adminCategoryListDto: AdminCategoryListDto = {
+                categories: categories,
+                totalCount: totalCount,
+                endPage: endPage,
+                pages: pages,
+            };
+
+            return adminCategoryListDto;
+        } catch (error) {
+            if (error instanceof Error) {
+                throw new Error(`${error.message}`);
+            } else {
+                throw new Error("카테고리 조회 실패: 알 수 없는 오류");
+            }
+        }
+    }
+}

--- a/application/usecase/category/GetCategoryListUsecase.ts
+++ b/application/usecase/category/GetCategoryListUsecase.ts
@@ -4,7 +4,7 @@ import { CategoryListDto } from "./dto/CategoryListDto";
 import { CategoryFilter } from "@/domain/repositories/filters/CategoryFilter";
 import { CategoryDto } from "./dto/CategoryDto";
 
-export class GetCategories {
+export class GetCategoryListUseCase {
     constructor(private categoryRepository: CategoryRepository) {}
 
     async execute(queryDto: GetCategoryListQueryDto): Promise<CategoryListDto> {

--- a/application/usecase/category/dto/AdminCategoryListDto.ts
+++ b/application/usecase/category/dto/AdminCategoryListDto.ts
@@ -1,0 +1,10 @@
+import { CategoryDto } from "./CategoryDto";
+
+export class AdminCategoryListDto {
+    constructor(
+        public categories: CategoryDto[],
+        public totalCount: number,
+        public endPage: number,
+        public pages: number[],
+    ) {}
+}

--- a/application/usecase/category/dto/GetAdminCategoryListQueryDto.ts
+++ b/application/usecase/category/dto/GetAdminCategoryListQueryDto.ts
@@ -1,0 +1,3 @@
+export class GetAdmincategoryListQueryDto {
+    constructor(public currentPage?: number) {}
+}

--- a/infra/repositories/supabase/SbCategoryRepository.ts
+++ b/infra/repositories/supabase/SbCategoryRepository.ts
@@ -8,9 +8,12 @@ export class SbCategoryRepository implements CategoryRepository {
     async count(): Promise<number> {
         const supabase = await createClient();
 
-        const { count, error } = await supabase
+        const { count, error, data } = await supabase
             .from("category")
-            .select("*", { count: "exact", head: true });
+            .select("*", {
+                count: "exact",
+                head: true,
+            });
 
         if (error) {
             throw new Error(`카테고리 개수를 가져올 수 없음: ${error.message}`);
@@ -28,7 +31,7 @@ export class SbCategoryRepository implements CategoryRepository {
             .order("habit_count", { ascending: false });
 
         if (filter) {
-            if (filter.offset) {
+            if (filter.offset !== undefined) {
                 query.range(
                     filter.offset,
                     filter.offset + (filter.limit || 0) - 1,
@@ -48,7 +51,8 @@ export class SbCategoryRepository implements CategoryRepository {
 
         return data.map((category) => {
             return {
-                ...category,
+                id: category.id,
+                name: category.name,
                 habitCount: category.habit_count,
             };
         });

--- a/utils/supabase/Server.ts
+++ b/utils/supabase/Server.ts
@@ -6,7 +6,7 @@ export async function createClient() {
 
     return createServerClient(
         process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        process.env.SUPABASE_SERVICE_ROLE_KEY!,
         {
             cookies: {
                 getAll() {
@@ -15,7 +15,7 @@ export async function createClient() {
                 setAll(cookiesToSet) {
                     try {
                         cookiesToSet.forEach(({ name, value, options }) =>
-                            cookieStore.set(name, value, options)
+                            cookieStore.set(name, value, options),
                         );
                     } catch {
                         // The `setAll` method was called from a Server Component.
@@ -24,6 +24,6 @@ export async function createClient() {
                     }
                 },
             },
-        }
+        },
     );
 }


### PR DESCRIPTION
## 카테고리 관리자 조회 기능
- dto 작성
  - 요청 관련 : GetAdminCategoryListqueryDto
  - 응답 관련 : AdminCategoryListDto
- 유즈케이스 작성
- api 작성 (`/api/admin/categories`)

## 폴더 구조 변경
> 관리자 페이지에서 사용하는 api url에 `/admin` 경로 추가
- 전 : `api/categories/[id]`
- 후: `api/admin/categories/[id]`

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
