### PR TITLE
[Feat/#52] 마이페이지에서 회원탈퇴기능 추가

### DIFF
--- a/app/api/members/withdraw/route.ts
+++ b/app/api/members/withdraw/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withdrawMemberUseCase } from "@/application/usecase/member/WithdrawMemberUsecase";
+
+export async function POST(req: NextRequest) {
+    const authHeader = req.headers.get("authorization");
+    const token = authHeader?.replace("Bearer ", "");
+
+    if (!token) {
+        return NextResponse.json({ error: "토큰 없음" }, { status: 401 });
+    }
+
+    try {
+        await withdrawMemberUseCase.execute(token);
+        return NextResponse.json({ message: "탈퇴 완료" });
+    } catch (error: any) {
+        return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+}

--- a/app/profile/components/WithdrawButton.tsx
+++ b/app/profile/components/WithdrawButton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function WithdrawButton() {
+    const router = useRouter();
+
+    const handleWithdraw = async () => {
+        const confirmed = window.confirm("정말 탈퇴하시겠습니까?");
+        if (!confirmed) return;
+
+        const token = localStorage.getItem("access_token");
+        if (!token) return;
+
+        const res = await fetch("/api/members/withdraw", {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        });
+
+        if (res.ok) {
+            localStorage.removeItem("access_token");
+            alert("탈퇴가 완료되었습니다.");
+            router.push("/login");
+        } else {
+            const data = await res.json();
+            alert(data.error || "탈퇴 실패");
+        }
+    };
+
+    return (
+        <button onClick={handleWithdraw} style={{ marginTop: "1rem", color: "gray" }}>
+            탈퇴하기
+        </button>
+    );
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import ProfileForm from "./components/ProfileForm";
 import LogoutButton from "./components/LogoutButton";
+import WithdrawButton from "./components/WithdrawButton";
 
 export default function ProfilePage() {
     const [profile, setProfile] = useState<any>(null);
@@ -40,6 +41,7 @@ export default function ProfilePage() {
         <>
             <ProfileForm profile={profile} />
             <LogoutButton />
+            <WithdrawButton />
         </>
     );
 }

--- a/application/usecase/member/LoginMemberUsecase.ts
+++ b/application/usecase/member/LoginMemberUsecase.ts
@@ -10,6 +10,10 @@ export const loginMemberUseCase = {
             throw new Error("이메일 또는 비밀번호가 일치하지 않습니다.");
         }
 
+        if (member.deletedAt !== null) {
+            throw new Error("탈퇴한 계정입니다.");
+        }
+
         const isValid = await bcrypt.compare(password, member.password);
         if (!isValid) {
             throw new Error("이메일 또는 비밀번호가 일치하지 않습니다.");

--- a/application/usecase/member/WithdrawMemberUsecase.ts
+++ b/application/usecase/member/WithdrawMemberUsecase.ts
@@ -1,9 +1,11 @@
-export class WithdrawMember {
-    constructor(private memberId: string) {}
+import { memberRepository } from "@/infra/repositories/supabase/SbMemberRepository";
+import { verifyJWT } from "@/utils/jwt";
 
-    public async execute(): Promise<void> {
-        // Logic for withdrawing a member from the application
-        // This could involve removing the member's data from the database
-        // and performing any necessary cleanup operations.
-    }
-}
+export const withdrawMemberUseCase = {
+    async execute(token: string) {
+        const payload = verifyJWT(token);
+        if (!payload) throw new Error("인증 실패");
+
+        await memberRepository.withdraw(payload.id);
+    },
+};

--- a/domain/repositories/MemberRepository.ts
+++ b/domain/repositories/MemberRepository.ts
@@ -5,4 +5,5 @@ export interface MemberRepository {
     findByEmail(email: string): Promise<Member | null>;
     findById(id: string): Promise<Member | null>;
     isEmailDuplicated(email: string): Promise<boolean>;
+    withdraw(id: string): Promise<void>;
 }

--- a/infra/repositories/supabase/SbMemberRepository.ts
+++ b/infra/repositories/supabase/SbMemberRepository.ts
@@ -98,4 +98,14 @@ export const memberRepository: MemberRepository = {
 
         return !!data; // data가 있으면 true (중복)
     },
+
+    withdraw: async (id: string) => {
+        const now = new Date().toISOString();
+        const { error } = await supabase
+            .from("member")
+            .update({ deleted_at: now })
+            .eq("id", id);
+
+        if (error) throw new Error(error.message);
+    },
 };


### PR DESCRIPTION
[브랜치 종류/#이슈번호]: 구현사항 요약
## 작업 내용
> 마이페이지에서 회원탈퇴기능 추가(실제 삭제X, deleted_at 추가)
> 로그인 시 탈퇴한 아이디는 로그인 안되도록 수정
