### PR TITLE
[Feat/#56] 카테고리 수정 및 api 요청 권한 검사 기능

### DIFF
--- a/app/api/admin/categories/[id]/route.ts
+++ b/app/api/admin/categories/[id]/route.ts
@@ -37,7 +37,7 @@ export async function PATCH(request: Request, { params }: RequestParams) {
     } catch (error) {
         if (error instanceof Error) {
             return NextResponse.json(
-                { message: error.message || "카테고리 생성 실패" },
+                { message: error.message || "카테고리 수정 실패" },
                 { status: 400 },
             );
         }

--- a/app/api/admin/categories/[id]/route.ts
+++ b/app/api/admin/categories/[id]/route.ts
@@ -1,0 +1,49 @@
+import { SbCategoryRepository } from "@/infra/repositories/supabase/SbCategoryRepository";
+import { UpdateCategoryUsecase } from "./../../../../../application/usecase/category/UpdateCategoryUsecase";
+import { NextResponse } from "next/server";
+
+type RequestParams = {
+    params: {
+        id: string;
+    };
+};
+
+export async function PATCH(request: Request, { params }: RequestParams) {
+    try {
+        const { id } = await params;
+        const body = await request.json();
+
+        if (!body.name) {
+            return NextResponse.json(
+                {
+                    message: "카테고리 이름이 없습니다.",
+                },
+                { status: 400 },
+            );
+        }
+
+        const updateCategoryUsecase = new UpdateCategoryUsecase(
+            new SbCategoryRepository(),
+        );
+
+        await updateCategoryUsecase.execute({
+            id: Number(id),
+            name: body.name,
+        });
+
+        return NextResponse.json({
+            message: "카테고리 수정 성공",
+        });
+    } catch (error) {
+        if (error instanceof Error) {
+            return NextResponse.json(
+                { message: error.message || "카테고리 생성 실패" },
+                { status: 400 },
+            );
+        }
+        return NextResponse.json(
+            { message: "알 수 없는 오류 발생" },
+            { status: 500 },
+        );
+    }
+}

--- a/app/api/admin/categories/route.ts
+++ b/app/api/admin/categories/route.ts
@@ -51,7 +51,7 @@ export async function POST(request: Request) {
             );
         }
 
-        const memberId = getMemberIdFromToken(
+        const memberId = await getMemberIdFromToken(
             request.headers.get("Authorization")!,
         );
 

--- a/application/usecase/category/UpdateCategoryUsecase.ts
+++ b/application/usecase/category/UpdateCategoryUsecase.ts
@@ -9,7 +9,6 @@ export class UpdateCategoryUsecase {
         const category: CategoryView = await this.categoryRepository.findById(
             updateDto.id,
         );
-        console.log(category);
         if (category.habitCount !== 0) {
             throw new Error("사용량이 0인 카테고리만 수정 가능합니다.");
         }

--- a/application/usecase/category/UpdateCategoryUsecase.ts
+++ b/application/usecase/category/UpdateCategoryUsecase.ts
@@ -1,0 +1,22 @@
+import { CategoryRepository } from "@/domain/repositories/CategoryRepository";
+import { UpdateCategoryDto } from "./dto/UpdateCategoryDto";
+import { CategoryView } from "@/domain/entities/CategoryView";
+
+export class UpdateCategoryUsecase {
+    constructor(private categoryRepository: CategoryRepository) {}
+
+    async execute(updateDto: UpdateCategoryDto) {
+        const category: CategoryView = await this.categoryRepository.findById(
+            updateDto.id,
+        );
+        console.log(category);
+        if (category.habitCount !== 0) {
+            throw new Error("사용량이 0인 카테고리만 수정 가능합니다.");
+        }
+
+        await this.categoryRepository.update({
+            id: updateDto.id,
+            name: updateDto.name,
+        });
+    }
+}

--- a/application/usecase/category/dto/UpdateCategoryDto.ts
+++ b/application/usecase/category/dto/UpdateCategoryDto.ts
@@ -1,0 +1,6 @@
+export class UpdateCategoryDto {
+    constructor(
+        public id: number,
+        public name: string,
+    ) {}
+}

--- a/application/usecase/member/LoginMemberUsecase.ts
+++ b/application/usecase/member/LoginMemberUsecase.ts
@@ -19,7 +19,7 @@ export const loginMemberUseCase = {
             throw new Error("이메일 또는 비밀번호가 일치하지 않습니다.");
         }
 
-        const token = signJWT({
+        const token = await signJWT({
             id: member.id,
             nickname: member.nickname,
             role: member.role,

--- a/domain/repositories/CategoryRepository.ts
+++ b/domain/repositories/CategoryRepository.ts
@@ -1,10 +1,12 @@
 import { Category } from "../entities/Category";
+import { CategoryView } from "../entities/CategoryView";
 import { CategoryFilter } from "./filters/CategoryFilter";
 
 export interface CategoryRepository {
     count(filter?: CategoryFilter): Promise<number>;
     findAll(filter?: CategoryFilter): Promise<Category[]>;
+    findById(id: number): Promise<CategoryView>;
     save(category: Category): Promise<Category>;
-    update(category: Category): Promise<Category>;
+    update(category: Category): Promise<void>;
     deleteById(id: number): Promise<void>;
 }

--- a/infra/repositories/supabase/SbCategoryRepository.ts
+++ b/infra/repositories/supabase/SbCategoryRepository.ts
@@ -56,6 +56,26 @@ export class SbCategoryRepository implements CategoryRepository {
         });
     }
 
+    async findById(id: number): Promise<CategoryView> {
+        const supabase = await createClient();
+
+        const { data, error } = await supabase
+            .from("category_view")
+            .select("*")
+            .eq("id", id)
+            .single();
+
+        if (error) {
+            throw new Error(`${error.message}`);
+        }
+
+        return {
+            name: data.name,
+            memberId: data.member_id,
+            habitCount: data.habit_count,
+        };
+    }
+
     async save(category: Category): Promise<Category> {
         const supabase = await createClient();
 
@@ -82,12 +102,12 @@ export class SbCategoryRepository implements CategoryRepository {
         };
     }
 
-    async update(category: Category): Promise<Category> {
+    async update(category: Category): Promise<void> {
         const supabase = await createClient();
 
         const updates: Pick<Category, "name"> = { name: category.name };
 
-        const { data, error } = await supabase
+        const { error } = await supabase
             .from("category")
             .update(updates)
             .eq("id", category.id)
@@ -97,12 +117,6 @@ export class SbCategoryRepository implements CategoryRepository {
         if (error) {
             throw new Error(`카테고리 수정 실패: ${error.message}`);
         }
-
-        return {
-            id: data.id,
-            name: data.name,
-            memberId: data.member_id,
-        };
     }
 
     async deleteById(id: number): Promise<void> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "bcrypt": "^5.1.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "jose": "^6.0.10",
         "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.468.0",
         "next": "latest",
@@ -3553,6 +3554,14 @@
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.10.tgz",
+      "integrity": "sha512-skIAxZqcMkOrSwjJvplIPYrlXGpxTPnro2/QWTDCxAdWQrSTV5/KqspMWmi5WAx5+ULswASJiZ0a+1B/Lxt9cw==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-yaml": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "bcrypt": "^5.1.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "jose": "^6.0.10",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.468.0",
     "next": "latest",

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -1,12 +1,11 @@
-import { verify } from "jsonwebtoken";
-import { NextApiRequest } from "next";
+import { verifyJWT } from "./jwt";
 
-export function getMemberIdFromToken(authHeader: string): string | null {
+export async function getMemberIdFromToken(authHeader: string) {
     const token = authHeader?.replace("Bearer ", "")!;
 
     try {
-        const decoded = verify(token, process.env.JWT_SECRET!);
-        const { id } = decoded as { id: string };
+        const payload = await verifyJWT(token);
+        const { id } = payload as { id: string };
         return id;
     } catch (err) {
         return null;

--- a/utils/jwt.ts
+++ b/utils/jwt.ts
@@ -1,15 +1,24 @@
-import jwt from "jsonwebtoken";
+import { jwtVerify, SignJWT } from "jose";
 
 const secret = process.env.JWT_SECRET!;
+type PayloadType = {
+    id: string;
+    nickname: string;
+    role: number;
+};
+export async function signJWT(payload: PayloadType, expiresIn = "1d") {
+    const secretKey = new TextEncoder().encode(secret);
+    const token = await new SignJWT(payload)
+        .setProtectedHeader({ alg: "HS256" })
+        .setExpirationTime(expiresIn)
+        .sign(secretKey);
 
-export function signJWT(payload: object, expiresIn = "1d") {
-    return jwt.sign(payload, secret, { expiresIn });
+    return token;
 }
 
-export function verifyJWT(token: string) {
-    try {
-        return jwt.verify(token, secret);
-    } catch {
-        return null;
-    }
+export async function verifyJWT(token: string) {
+    const secretKey = new TextEncoder().encode(secret);
+    const { payload } = await jwtVerify(token, secretKey);
+
+    return payload;
 }


### PR DESCRIPTION
## 작업 내용
> ### 카테고리 수정
- 관리자가 사용량이 0인 카테고리에 대해서만 이름 변경 가능하도록 구현
- dto, usecase, api 작성

> ### api 요청 권한 검사
- middleware.ts
  - 사용자 인증이 필요없는 api url은 PUBLIC_PATHS로 관리
  - 나머지 api 요청에 대해서는 jwt 토큰 검증을 통해 권한 확인
  - 로그인하지 않은 경우 401, 관리자 권한이 없는 경우 403으로 응답
- 토큰 발급 라이브러리를 jsonwebtoken에서 jose로 변경

