### PR TITLE
[feat/#47]: message 조회 페이지 구현

### DIFF
--- a/app/common-components/Pager.module.scss
+++ b/app/common-components/Pager.module.scss
@@ -1,0 +1,37 @@
+.pager-box {
+    width: 100%;
+    max-width: 600px;
+    height: 100%;
+    margin: 0 auto;
+    padding: 40px;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    > .pager {
+        > h1 {
+            display: none;
+        }
+
+        > button {
+            padding: 0.5rem 0.75rem;
+            border: 1px solid #ccc;
+            background-color: white;
+            color: #333;
+            border-radius: 4px;
+            cursor: pointer;
+            transition: background-color 0.2s ease;
+
+            &:hover:not(.disabled) {
+                background-color: #f0f0f0;
+            }
+        }
+
+        > .disabled {
+            opacity: 0.5;
+            pointer-events: none;
+            cursor: not-allowed;
+        }
+    }
+}

--- a/app/common-components/Pager.tsx
+++ b/app/common-components/Pager.tsx
@@ -3,6 +3,12 @@
 import React, { FC } from "react";
 import styles from "./Pager.module.scss";
 
+const {
+    ["pager-box"]: pagerBox,
+    ["pager"]: pager,
+    ["disabled"]: disabled,
+} = styles;
+
 type PagerProps = {
     currentPage: number;
     endPage: number;
@@ -25,40 +31,44 @@ const Pager: FC<PagerProps> = ({
     const hasPreviousPage = currentPage > pageSize;
 
     return (
-        <section className="d:flex jc:center ai:center gap:2 h:100p">
-            <h1 className="d:none">페이저</h1>
-            {hasPreviousPage ? (
-                <button
-                    className="n-btn"
-                    onClick={() => onPageChange(Math.max(currentPage - 1, 1))}
-                >
-                    이전
-                </button>
-            ) : (
-                <div className="n-btn disabled">이전</div>
-            )}
-            <ul className="n-bar">
-                {pages.map((pageNumber) => (
-                    <li key={pageNumber}>
-                        <button
-                            className={`n-btn ${pageNumber === currentPage ? "active" : ""}`}
-                            onClick={() => onPageChange(pageNumber)}
-                        >
-                            {pageNumber}
-                        </button>
-                    </li>
-                ))}
-            </ul>
-            {hasNextPage ? (
-                <button
-                    className="n-btn"
-                    onClick={() => onPageChange(Math.max(currentPage - 1, 1))}
-                >
-                    다음
-                </button>
-            ) : (
-                <div className="n-btn disabled">다음</div>
-            )}
-        </section>
+        <div className={pagerBox}>
+            <section className={pager}>
+                <h1>페이저</h1>
+                {hasPreviousPage ? (
+                    <button
+                        onClick={() =>
+                            onPageChange(Math.max(currentPage - 1, 1))
+                        }
+                    >
+                        이전
+                    </button>
+                ) : (
+                    <div className={disabled}>이전</div>
+                )}
+                <ul>
+                    {pages.map((pageNumber) => (
+                        <li key={pageNumber}>
+                            <button
+                                className={`${pageNumber === currentPage ? "active" : ""}`}
+                                onClick={() => onPageChange(pageNumber)}
+                            >
+                                {pageNumber}
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+                {hasNextPage ? (
+                    <button
+                        onClick={() =>
+                            onPageChange(Math.max(currentPage - 1, 1))
+                        }
+                    >
+                        다음
+                    </button>
+                ) : (
+                    <div className={disabled}>다음</div>
+                )}
+            </section>
+        </div>
     );
 };

--- a/app/common-components/Pager.tsx
+++ b/app/common-components/Pager.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import React, { FC } from "react";
+import styles from "./Pager.module.scss";
+
+type PagerProps = {
+    currentPage: number;
+    endPage: number;
+    pageSize: number; // number of pages to show in the pager
+    onPageChange: (newPage: number) => void;
+};
+
+const Pager: FC<PagerProps> = ({
+    currentPage,
+    endPage,
+    pageSize,
+    onPageChange,
+}) => {
+    const startNumber = Math.floor((currentPage - 1) / pageSize) * pageSize + 1;
+    const pages = Array.from(
+        { length: pageSize },
+        (_, i) => startNumber + i,
+    ).filter((page) => page <= endPage);
+    const hasNextPage = startNumber + pageSize <= endPage;
+    const hasPreviousPage = currentPage > pageSize;
+
+    return (
+        <section className="d:flex jc:center ai:center gap:2 h:100p">
+            <h1 className="d:none">페이저</h1>
+            {hasPreviousPage ? (
+                <button
+                    className="n-btn"
+                    onClick={() => onPageChange(Math.max(currentPage - 1, 1))}
+                >
+                    이전
+                </button>
+            ) : (
+                <div className="n-btn disabled">이전</div>
+            )}
+            <ul className="n-bar">
+                {pages.map((pageNumber) => (
+                    <li key={pageNumber}>
+                        <button
+                            className={`n-btn ${pageNumber === currentPage ? "active" : ""}`}
+                            onClick={() => onPageChange(pageNumber)}
+                        >
+                            {pageNumber}
+                        </button>
+                    </li>
+                ))}
+            </ul>
+            {hasNextPage ? (
+                <button
+                    className="n-btn"
+                    onClick={() => onPageChange(Math.max(currentPage - 1, 1))}
+                >
+                    다음
+                </button>
+            ) : (
+                <div className="n-btn disabled">다음</div>
+            )}
+        </section>
+    );
+};

--- a/app/message/page.tsx
+++ b/app/message/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { MessageDto } from "@/application/usecase/message/dto/MessageDto";
+import { MessageListDto } from "@/application/usecase/message/dto/MessageListDto";
+import { useMemberStore } from "@/stores/memberStore";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+export default function MessageListPage() {
+    const searchParams = useSearchParams();
+
+    const currentPageParam = searchParams.get("currentPage");
+    const mineParam = searchParams.get("mine");
+
+    const { token } = useMemberStore();
+
+    // page state initialization
+    const [currentPage, setCurrentPage] = useState<number>(1);
+    const [mine, setMine] = useState<boolean>(false);
+    const [messages, setMessages] = useState<MessageDto[]>([]);
+    const [pages, setPages] = useState<number[]>([]);
+
+    // query params initialization
+    if (currentPageParam) setCurrentPage(Number(currentPageParam));
+    if (mineParam) setMine(mineParam === "true");
+
+    useEffect(() => {
+        async function fetchMessages() {
+            try {
+                const params = new URLSearchParams();
+
+                // append query parameters to params
+                params.append("currentPage", currentPage.toString());
+                params.append("mine", mine.toString());
+
+                console.log("params", params.toString());
+
+                // call API
+                const response = await fetch(
+                    `/api/messages?${params.toString()}`,
+                    {
+                        headers: {
+                            Authorization: `Bearer ${token}`,
+                        },
+                    },
+                );
+
+                const data: MessageListDto = await response.json();
+                console.log("data", data);
+
+                // update state with the fetched data
+                setMessages(data.messages);
+                setPages(data.pages);
+            } catch (error) {
+                console.error("Failed to fetch messages:", error);
+            }
+        }
+
+        fetchMessages();
+    }, [currentPage, mine, token]);
+
+    return {};
+}

--- a/app/message/page.tsx
+++ b/app/message/page.tsx
@@ -76,7 +76,26 @@ export default function MessageListPage() {
             <ol>
                 {messages.map((message) => (
                     <li key={message.id}>
-                        <div></div>
+                        <div>
+                            <img
+                                src={message.profileUrl}
+                                width={40}
+                                height={40}
+                            />
+                            <div>
+                                <strong>{message.writer}</strong>
+                                <span>{message.createdAt.toISOString()}</span>
+                            </div>
+                        </div>
+
+                        <p>{message.content}</p>
+
+                        <div>
+                            <button>
+                                {message.isLiked ? "❤️" : "🤍"}{" "}
+                                {message.likeCount}
+                            </button>
+                        </div>
                     </li>
                 ))}
             </ol>

--- a/app/message/page.tsx
+++ b/app/message/page.tsx
@@ -59,5 +59,19 @@ export default function MessageListPage() {
         fetchMessages();
     }, [currentPage, mine, token]);
 
-    return {};
+    return (
+        <main>
+            <header>
+                <h1>Daily Message</h1>
+                <ol>
+                    <li>
+                        <button>전체</button>
+                    </li>
+                    <li>
+                        <button>내 메시지</button>
+                    </li>
+                </ol>
+            </header>
+        </main>
+    );
 }

--- a/app/message/page.tsx
+++ b/app/message/page.tsx
@@ -72,6 +72,14 @@ export default function MessageListPage() {
                     </li>
                 </ol>
             </header>
+
+            <ol>
+                {messages.map((message) => (
+                    <li key={message.id}>
+                        <div></div>
+                    </li>
+                ))}
+            </ol>
         </main>
     );
 }

--- a/application/usecase/message/dto/MessageDto.ts
+++ b/application/usecase/message/dto/MessageDto.ts
@@ -7,6 +7,6 @@ export class MessageDto {
         public createdAt: Date,
         public likeCount: number,
         public isLiked: boolean,
-        public modifiedAt?: Date, // can be null if message is not modified
+        public modifiedAt: Date | null, // can be null if message is not modified
     ) {}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "change_me",
+  "name": "Change_me",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
[브랜치 종류/#이슈번호]: 구현사항 요약
## 작업 내용
(개발용) app/message 폴더 구성
api(GET) fetch 구현
UI 구현 (스타일 미적용)
common-components에 Pager.tsx 구현
Pager.module.scss 생성
MessageDto 내의 modifiedAt type 수정
> 작업 이미지 (FE 경우)

## 리뷰 요구사항 (선택)
1. 개발 기간동안에는 오늘의 루틴 페이지 하나에 통합해서 개발하는 대신
습관 / 메시지 기능을 독립적으로 개발해나갈 예정입니다.
추후 마무리 단계에서 합쳐는 과정이 필요해요.
2. 페이지네이션 하시는 페이지에서 Pager 컴포넌트 사용해주시면 됩니다. 스타일링 수정 사항은 Pagers.module.scss에서 수정해주세요.
