### PR TITLE
[Style/#108] 마이페이지 css, 마이페이지에서 프로필정보 가져오는 부분, 탈퇴하기에서 getMemberIdFromToken 사용하도록 수정

### DIFF
--- a/app/(base)/member/profile/components/ChangePasswordButton.module.scss
+++ b/app/(base)/member/profile/components/ChangePasswordButton.module.scss
@@ -1,0 +1,13 @@
+.changePasswordButton {
+    margin-top: 1rem;
+    background-color: transparent;
+    color: gray;
+    font-size: var(--fontSize-sm);
+    border: none;
+    cursor: pointer;
+    transition: color 0.3s ease;
+
+    &:hover {
+        color: var(--color-red);
+    }
+}

--- a/app/(base)/member/profile/components/ChangePasswordButton.tsx
+++ b/app/(base)/member/profile/components/ChangePasswordButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import styles from "./ChangePasswordButton.module.scss";
 
 export default function ChangePasswordButton() {
     const router = useRouter();
@@ -10,8 +11,8 @@ export default function ChangePasswordButton() {
     };
 
     return (
-        <button onClick={handleClick}>
-            비밀번호 수정하기
+        <button onClick={handleClick} className={styles.changePasswordButton}>
+            비밀번호 변경하기
         </button>
     );
 }

--- a/app/(base)/member/profile/components/ProfileForm.module.scss
+++ b/app/(base)/member/profile/components/ProfileForm.module.scss
@@ -1,0 +1,75 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 2rem;
+}
+
+.title {
+    font-size: var(--fontSize-xl);
+    font-weight: var(--fontWeight-bold);
+}
+
+.avatar {
+    width: 140px;
+    height: 140px;
+    border-radius: 20%;
+    overflow: hidden;
+    border: 3px solid white;
+    box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
+    cursor: pointer;
+}
+
+.joinedDate {
+    font-size: var(--fontSize-sm);
+    color: var(--color-gray);
+}
+
+.infoGroup {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: 320px;
+}
+
+.row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    strong {
+        width: 100px;
+        font-weight: bold;
+        color: var(--color-text);
+    }
+
+    div {
+        flex: 1;
+        text-align: left;
+    }
+
+    input {
+        flex: 1;
+        padding: 0.4rem 0.6rem;
+        border: 1px solid var(--color-gray);
+        border-radius: 4px;
+    }
+}
+
+.error {
+    font-size: var(--fontSize-xs);
+    color: var(--color-red);
+    text-align: right;
+}
+
+.submitButton {
+    margin-top: 1.5rem;
+    background-color: var(--color-main1);
+    color: white;
+    padding: 0.6rem 1.2rem;
+    border-radius: 5px;
+    font-weight: bold;
+    border: none;
+    cursor: pointer;
+}

--- a/app/(base)/member/profile/components/ProfileForm.tsx
+++ b/app/(base)/member/profile/components/ProfileForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useRef, useState } from "react";
 import Image from "next/image";
+import styles from "./ProfileForm.module.scss";
 
 type Props = {
     profile: {
@@ -99,31 +100,17 @@ export default function ProfileForm({ profile }: Props) {
     };
 
     return (
-        <div>
-            <h2>프로필</h2>
+        <div className={styles.container}>
+            <h2 className={styles.title}>프로필</h2>
 
-            <div style={{ position: "relative", display: "inline-block", marginBottom: "1rem" }}>
-                <div
-                    onClick={handleImageClick}
-                    style={{
-                        borderRadius: "50%",
-                        overflow: "hidden",
-                        width: 140,
-                        height: 140,
-                        border: "3px solid white",
-                        cursor: "pointer",
-                        boxShadow: "0 0 5px rgba(0,0,0,0.2)",
-                    }}
-                >
-                    <Image
-                        src={preview || "/images/ProfileSquare.png"}
-                        alt="프로필 이미지"
-                        width={140}
-                        height={140}
-                        style={{ objectFit: "cover" }}
-                    />
-                </div>
-
+            <div onClick={handleImageClick} className={styles.avatar}>
+                <Image
+                    src={preview || "/images/ProfileSquare.png"}
+                    alt="프로필 이미지"
+                    width={140}
+                    height={140}
+                    style={{ objectFit: "cover" }}
+                />
                 <input
                     type="file"
                     accept="image/*"
@@ -132,13 +119,21 @@ export default function ProfileForm({ profile }: Props) {
                     style={{ display: "none" }}
                 />
             </div>
+            <p className={styles.joinedDate}>{formattedDate} 가입</p>
 
-            <p>{formattedDate} 가입</p>
-            <div>
-                <strong>이름</strong> <div>{profile.name}</div>
-                <strong>이메일</strong> <div>{profile.email}</div>
-                <strong>비밀번호 확인</strong><br />
-                <div>
+            <div className={styles.infoGroup}>
+                <div className={styles.row}>
+                    <strong>이름</strong>
+                    <div>{profile.name}</div>
+                </div>
+
+                <div className={styles.row}>
+                    <strong>이메일</strong>
+                    <div>{profile.email}</div>
+                </div>
+
+                <div className={styles.row}>
+                    <strong>비밀번호</strong>
                     <input
                         type="password"
                         value={password}
@@ -146,8 +141,10 @@ export default function ProfileForm({ profile }: Props) {
                         placeholder="비밀번호 입력"
                     />
                 </div>
-                <strong>닉네임</strong>
-                <div>
+                {password === "" && <div className={styles.error}>비밀번호를 입력해주세요.</div>}
+
+                <div className={styles.row}>
+                    <strong>닉네임</strong>
                     <input
                         type="text"
                         value={nickname}
@@ -155,8 +152,14 @@ export default function ProfileForm({ profile }: Props) {
                         placeholder="닉네임"
                     />
                 </div>
+                {nickname.length > 20 && (
+                    <div className={styles.error}>20자 이내로 작성해주세요.</div>
+                )}
+
+                <button className={styles.submitButton} onClick={handleSubmit}>
+                    수정
+                </button>
             </div>
-            <button onClick={handleSubmit}>수정</button>
         </div>
     );
 }

--- a/app/(base)/member/profile/components/WithdrawButton.module.scss
+++ b/app/(base)/member/profile/components/WithdrawButton.module.scss
@@ -1,0 +1,13 @@
+.withdrawButton {
+    margin-top: 1rem;
+    background-color: transparent;
+    color: gray;
+    font-size: var(--fontSize-sm);
+    border: none;
+    cursor: pointer;
+    transition: color 0.3s ease;
+
+    &:hover {
+        color: var(--color-red);
+    }
+}

--- a/app/(base)/member/profile/components/WithdrawButton.tsx
+++ b/app/(base)/member/profile/components/WithdrawButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import styles from "./WithdrawButton.module.scss";
 
 export default function WithdrawButton() {
     const router = useRouter();
@@ -30,7 +31,7 @@ export default function WithdrawButton() {
     };
 
     return (
-        <button onClick={handleWithdraw} style={{ marginTop: "1rem", color: "gray" }}>
+        <button onClick={handleWithdraw} className={styles.withdrawButton}>
             탈퇴하기
         </button>
     );

--- a/app/(base)/member/profile/page.module.scss
+++ b/app/(base)/member/profile/page.module.scss
@@ -1,0 +1,11 @@
+.pageWrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.actionButtons {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}

--- a/app/(base)/member/profile/page.tsx
+++ b/app/(base)/member/profile/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 import { useEffect, useState } from "react";
 import ProfileForm from "./components/ProfileForm";
-import LogoutButton from "./components/LogoutButton";
 import WithdrawButton from "./components/WithdrawButton";
 import ChangePasswordButton from "./components/ChangePasswordButton";
+import styles from "./page.module.scss";
 
 export default function ProfilePage() {
     const [profile, setProfile] = useState<any>(null);
@@ -33,11 +33,13 @@ export default function ProfilePage() {
     if (!profile) return <p>로딩 중...</p>;
 
     return (
-        <>
+        <div className={styles.pageWrapper}>
             <ProfileForm profile={profile} />
-            <LogoutButton />
-            <ChangePasswordButton />
-            <WithdrawButton />
-        </>
+
+            <div className={styles.actionButtons}>
+                <ChangePasswordButton />
+                <WithdrawButton />
+            </div>
+        </div>
     );
 }

--- a/app/api/members/profile/route.ts
+++ b/app/api/members/profile/route.ts
@@ -1,16 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { GetProfileUseCase } from "@/application/usecase/member/GetProfileUsecase";
 import { SbMemberRepository } from "@/infra/repositories/supabase/SbMemberRepository";
+import { getMemberIdFromToken } from "@/utils/auth";
 
 export async function GET(req: NextRequest) {
     const authHeader = req.headers.get("authorization");
-    const token = authHeader?.replace("Bearer ", "");
+    const memberId = await getMemberIdFromToken(authHeader!);
 
     try {
         const memberRepository = new SbMemberRepository();
         const getProfileUseCase = new GetProfileUseCase(memberRepository);
 
-        const profile = await getProfileUseCase.execute(token!);
+        const profile = await getProfileUseCase.execute(memberId!);
         return NextResponse.json(profile);
     } catch (err) {
         return NextResponse.json({ error: "인증 실패" }, { status: 401 });

--- a/app/api/members/withdraw/route.ts
+++ b/app/api/members/withdraw/route.ts
@@ -1,15 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { SbMemberRepository } from "@/infra/repositories/supabase/SbMemberRepository";
 import { WithdrawMemberUseCase } from "@/application/usecase/member/WithdrawMemberUsecase";
+import { getMemberIdFromToken } from "@/utils/auth";
 
 export async function POST(req: NextRequest) {
     const authHeader = req.headers.get("authorization");
-    const token = authHeader?.replace("Bearer ", "");
+    const memberId = await getMemberIdFromToken(authHeader!);
 
     try {
         const memberRepository = new SbMemberRepository();
         const withdrawMemberUseCase = new WithdrawMemberUseCase(memberRepository);
-        await withdrawMemberUseCase.execute(token!);
+        await withdrawMemberUseCase.execute(memberId!);
 
         return NextResponse.json({ message: "탈퇴 완료" });
     } catch (error: any) {

--- a/application/usecase/member/GetProfileUsecase.ts
+++ b/application/usecase/member/GetProfileUsecase.ts
@@ -1,18 +1,11 @@
 import { MemberRepository } from "@/domain/repositories/MemberRepository";
-import { verifyJWT } from "@/utils/jwt";
 import { ProfileDto } from "./dto/GetProfileDto";
 
 export class GetProfileUseCase {
     constructor(private readonly memberRepository: MemberRepository) { }
 
-    async execute(token: string): Promise<ProfileDto> {
-        const payload = await verifyJWT(token);
-
-        if (!payload || typeof payload !== "object" || !("id" in payload)) {
-            throw new Error("인증 실패");
-        }
-
-        const member = await this.memberRepository.findById(payload.id as string);
+    async execute(memberId: string): Promise<ProfileDto> {
+        const member = await this.memberRepository.findById(memberId as string);
         if (!member) throw new Error("사용자 없음");
 
         return new ProfileDto(

--- a/application/usecase/member/WithdrawMemberUsecase.ts
+++ b/application/usecase/member/WithdrawMemberUsecase.ts
@@ -4,12 +4,7 @@ import { verifyJWT } from "@/utils/jwt";
 export class WithdrawMemberUseCase {
     constructor(private readonly memberRepository: MemberRepository) { }
 
-    async execute(token: string): Promise<void> {
-        const payload = await verifyJWT(token);
-        if (!payload || typeof payload !== "object" || !("id" in payload)) {
-            throw new Error("인증 실패");
-        }
-
-        await this.memberRepository.withdraw(payload.id as string);
+    async execute(memberId: string): Promise<void> {
+        await this.memberRepository.withdraw(memberId as string);
     }
 }


### PR DESCRIPTION
[Style/#108] 마이페이지 css, 마이페이지에서 프로필정보 가져오는 부분, 탈퇴하기에서 getMemberIdFromToken 사용하도록 수정
## 작업 내용
>  마이페이지 css
> 마이페이지에서 프로필정보 가져오는 부분, 탈퇴하기에서 getMemberIdFromToken 사용하도록 수정
> 작업 이미지 (FE 경우)
![20250418231920](https://github.com/user-attachments/assets/6f5c36b5-ff00-40a9-a972-7a99f3422e79)


## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
