### PR TITLE
[fix/#114] Message 조회 관련 오류 수정

### DIFF
--- a/app/api/members/messages/route.ts
+++ b/app/api/members/messages/route.ts
@@ -6,7 +6,7 @@ import { NextResponse } from "next/server";
 import { MessageListDto } from "@/application/usecase/message/dto/MessageListDto";
 import { MessageRepository } from "@/domain/repositories/MessageRepository";
 import { MemberRepository } from "@/domain/repositories/MemberRepository";
-import { GetMessageListQueryDto } from "@/application/usecase/message/dto/GetMessageListQueryDto";
+import { GetMessageListDto } from "@/application/usecase/message/dto/GetMessageListDto";
 import { getMemberIdFromToken } from "@/utils/auth";
 import { CreateMessageDto } from "@/application/usecase/message/dto/CreateMessageDto";
 import { CreateMessageUsecase } from "@/application/usecase/message/CreateMessageUsecase";
@@ -32,7 +32,7 @@ export async function GET(request: Request) {
         );
 
         // set up query Dto
-        const queryDto = new GetMessageListQueryDto(
+        const queryDto = new GetMessageListDto(
             Number(currentPageParam),
             mineParam === "true",
         );

--- a/application/usecase/message/CreateMessageUsecase.ts
+++ b/application/usecase/message/CreateMessageUsecase.ts
@@ -11,7 +11,7 @@ export class CreateMessageUsecase {
 
     async execute(createMessageDto: CreateMessageDto): Promise<Message> {
         const message: Message = new Message(
-            null,
+            -1, // ignore it, message id is auto-incremented by supabase.
             createMessageDto.memberId,
             createMessageDto.content,
             new Date(),

--- a/application/usecase/message/dto/GetMessageListDto.ts
+++ b/application/usecase/message/dto/GetMessageListDto.ts
@@ -1,0 +1,9 @@
+export class GetMessageListDto {
+    constructor(
+        public queryString: {
+            currentPage?: number; // current page number
+            mine?: boolean;
+        },
+        public memberId: string,
+    ) {}
+}

--- a/application/usecase/message/dto/GetMessageListQueryDto.ts
+++ b/application/usecase/message/dto/GetMessageListQueryDto.ts
@@ -1,6 +1,0 @@
-export class GetMessageListQueryDto {
-    constructor(
-        public currentPage?: number, // current page number
-        public mine?: boolean,
-    ) {}
-}

--- a/domain/entities/Message.ts
+++ b/domain/entities/Message.ts
@@ -1,6 +1,6 @@
 export class Message {
     constructor(
-        public id: number | null, // null only if message is created
+        public id: number, // null only if message is created
         public memberId: string,
         public content: string,
         public createdAt: Date,

--- a/domain/repositories/filters/MessageFilter.ts
+++ b/domain/repositories/filters/MessageFilter.ts
@@ -1,9 +1,9 @@
 export class MessageFilter {
     constructor(
-        public memberId?: string,
+        public memberId: string | null,
         public sortField?: string, // to support multiple sorting options later
         public ascending?: boolean,
         public offset: number = 0,
-        public limit: number = 5
+        public limit: number = 5,
     ) {}
 }

--- a/domain/repositories/filters/MessageLikeFilter.ts
+++ b/domain/repositories/filters/MessageLikeFilter.ts
@@ -1,6 +1,6 @@
 export class MessageLikeFilter {
     constructor(
-        public messageId?: number,
-        public memberId?: string,
+        public messageId: number | null,
+        public memberId: string | null,
     ) {}
 }


### PR DESCRIPTION
## 작업 내용
메시지 목록 조회 usecase에서 받아오는 인자를 queryString과 memberId로 분리하여 사용
기존의 GetMessageListQueryDto를 GetMessageListDto로 수정.
해당 내용 수정으로 인한 변경사항 일괄 적용.
> 작업 이미지 (FE 경우)

## 리뷰 요구사항 (선택)
해당 커밋에는 entity, repository. filter 등의 변경이 존재합니다. 이후 작업 과정에서 해당 변경으로 인한 에러 발생 시 저에게 물어봐주세요.

