### PR TITLE
[Feat/#124] API 연동 관련 fetcher 및 카테고리 관리 api hook 작성

### DIFF
--- a/app/admin/components/CategoryItem.tsx
+++ b/app/admin/components/CategoryItem.tsx
@@ -4,11 +4,20 @@ import React from "react";
 import styles from "./CategoryItem.module.scss";
 
 type CategoryItemProps = {
+    id: number;
     name: string;
     habitCount: number;
+    handleDelete: (id: number) => void;
+    handleUpdate: (id: number, name: string) => void;
 };
 
-export default function CategoryItem({ name, habitCount }: CategoryItemProps) {
+export default function CategoryItem({
+    id,
+    name,
+    habitCount,
+    handleDelete,
+    handleUpdate,
+}: CategoryItemProps) {
     return (
         <li className={styles.row}>
             <span>{name}</span>
@@ -23,7 +32,11 @@ export default function CategoryItem({ name, habitCount }: CategoryItemProps) {
                 >
                     수정
                 </button>
-                <button disabled={habitCount !== 0} className={styles.delete}>
+                <button
+                    disabled={habitCount !== 0}
+                    className={styles.delete}
+                    onClick={() => handleDelete(id)}
+                >
                     삭제
                 </button>
             </div>

--- a/app/admin/components/CategoryList.tsx
+++ b/app/admin/components/CategoryList.tsx
@@ -3,14 +3,24 @@ import Pager from "@/app/components/Pager";
 import React from "react";
 import styles from "./CategoryList.module.scss";
 import CategoryItem from "./CategoryItem";
-
-const categories = [
-    { id: 1, name: "운동", habitCount: 0 },
-    { id: 2, name: "공부", habitCount: 10000000 },
-    { id: 3, name: "생활습관", habitCount: 532 },
-];
+import { useAdminCategories } from "@/hooks/useAdminCategories";
+import Loading from "@/app/components/Loading";
+import { useSearchParams, useRouter } from "next/navigation";
 
 export default function CategoryList() {
+    const searchParams = useSearchParams();
+    const router = useRouter();
+    const currentPage = Number(searchParams.get("page")) || 1;
+
+    const { categories, pages, endPage, isLoading, error } =
+        useAdminCategories(currentPage);
+
+    const handlePageChange = (page: number) => {
+        router.push(`?page=${page}`);
+    };
+
+    if (isLoading) return <Loading />;
+
     return (
         <div className={styles.wrapper}>
             <div className={styles.index}>
@@ -20,7 +30,7 @@ export default function CategoryList() {
             </div>
 
             <ul className={styles.list}>
-                {categories.map((category) => (
+                {categories?.map((category) => (
                     <CategoryItem
                         key={category.id}
                         name={category.name}
@@ -30,9 +40,9 @@ export default function CategoryList() {
             </ul>
             <Pager
                 currentPage={1}
-                pages={[1, 2, 3, 4, 5]}
-                endPage={10}
-                onPageChange={(page: number) => {}}
+                pages={pages}
+                endPage={endPage}
+                onPageChange={(page: number) => handlePageChange(page)}
             />
         </div>
     );

--- a/app/admin/components/CategoryList.tsx
+++ b/app/admin/components/CategoryList.tsx
@@ -12,8 +12,14 @@ export default function CategoryList() {
     const router = useRouter();
     const currentPage = Number(searchParams.get("page")) || 1;
 
-    const { categories, pages, endPage, isLoading, error } =
-        useAdminCategories(currentPage);
+    const {
+        categories,
+        pages,
+        endPage,
+        isLoading,
+        deleteCategory,
+        updateCategory,
+    } = useAdminCategories(currentPage);
 
     const handlePageChange = (page: number) => {
         router.push(`?page=${page}`);
@@ -33,8 +39,11 @@ export default function CategoryList() {
                 {categories?.map((category) => (
                     <CategoryItem
                         key={category.id}
+                        id={category.id}
                         name={category.name}
                         habitCount={category.habitCount}
+                        handleDelete={deleteCategory}
+                        handleUpdate={updateCategory}
                     />
                 ))}
             </ul>

--- a/app/admin/components/Title.tsx
+++ b/app/admin/components/Title.tsx
@@ -6,6 +6,7 @@ import styles from "./Title.module.scss";
 
 export default function Title() {
     const { openModal } = useModalStore();
+
     return (
         <div className={styles.title}>
             <h2>카테고리 관리</h2>

--- a/hooks/useAdminCategories.ts
+++ b/hooks/useAdminCategories.ts
@@ -2,7 +2,7 @@ import { fetcher } from "@/utils/fetcher";
 import useSWR, { mutate } from "swr";
 
 export type AdminCategory = {
-    id: string;
+    id: number;
     name: string;
     habitCount: number;
 };
@@ -35,7 +35,7 @@ export const useAdminCategories = (currentPage: number) => {
         mutate(getUrl);
     };
 
-    const deleteCategory = async (id: string) => {
+    const deleteCategory = async (id: number) => {
         await fetcher(`/api/admin/categories/${id}`, {
             method: "DELETE",
         });

--- a/hooks/useAdminCategories.ts
+++ b/hooks/useAdminCategories.ts
@@ -1,0 +1,56 @@
+import { fetcher } from "@/utils/fetcher";
+import useSWR, { mutate } from "swr";
+
+export type AdminCategory = {
+    id: string;
+    name: string;
+    habitCount: number;
+};
+
+export type ResponseType = {
+    categories: AdminCategory[];
+    endPage: number;
+    pages: number[];
+    totalCount: number;
+};
+
+export const useAdminCategories = (currentPage: number) => {
+    const getUrl = `/api/admin/categories?currentPage=${currentPage}`;
+
+    const { data, error, isLoading } = useSWR<ResponseType>(getUrl, fetcher);
+
+    const createCategory = async (category: Pick<AdminCategory, "name">) => {
+        await fetcher("/api/admin/categories", {
+            method: "POST",
+            body: category,
+        });
+        mutate(getUrl);
+    };
+
+    const updateCategory = async (id: number, name: string) => {
+        await fetcher(`/api/admin/categories/${id}`, {
+            method: "PATCH",
+            body: { name },
+        });
+        mutate(getUrl);
+    };
+
+    const deleteCategory = async (id: string) => {
+        await fetcher(`/api/admin/categories/${id}`, {
+            method: "DELETE",
+        });
+        mutate(getUrl);
+    };
+
+    return {
+        categories: data?.categories || [],
+        totalCount: data?.totalCount || 0,
+        endPage: data?.endPage || 1,
+        pages: data?.pages || [],
+        isLoading,
+        error,
+        createCategory,
+        updateCategory,
+        deleteCategory,
+    };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Change_me",
+  "name": "change_me",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -22,6 +22,7 @@
         "next-themes": "^0.4.3",
         "react": "19.0.0",
         "react-dom": "19.0.0",
+        "swr": "^2.3.3",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -2702,6 +2703,14 @@
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
@@ -5107,6 +5116,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
+      "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.3.tgz",
@@ -5413,6 +5434,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "next-themes": "^0.4.3",
     "react": "19.0.0",
     "react-dom": "19.0.0",
+    "swr": "^2.3.3",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,28 +1,34 @@
 {
-  "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
+    "compilerOptions": {
+        "target": "es5",
+        "lib": ["dom", "dom.iterable", "esnext"],
+        "allowJs": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "forceConsistentCasingInFileNames": true,
+        "noEmit": true,
+        "esModuleInterop": true,
+        "module": "esnext",
+        "moduleResolution": "node",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "jsx": "preserve",
+        "incremental": true,
+        "plugins": [
+            {
+                "name": "next"
+            }
+        ],
+        "paths": {
+            "@/*": ["./*"]
+        }
+    },
+    "include": [
+        "next-env.d.ts",
+        "**/*.ts",
+        "**/*.tsx",
+        ".next/types/**/*.ts",
+        "hooks/useCategories.tss"
     ],
-    "paths": {
-      "@/*": ["./*"]
-    }
-  },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+    "exclude": ["node_modules"]
 }

--- a/utils/fetcher.ts
+++ b/utils/fetcher.ts
@@ -1,0 +1,47 @@
+import { getToken } from "./utils";
+
+type FetcherOptions = {
+    method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+    body?: any;
+    headers?: Record<string, string>;
+};
+
+export async function fetcher<T>(
+    url: string,
+    options: FetcherOptions = {},
+): Promise<T> {
+    const token = getToken();
+    const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+    const response = await fetch(`${baseUrl}${url}`, {
+        method: options.method || "GET",
+        headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+            ...options.headers,
+        },
+        body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+
+    const data = await response.json();
+
+    if (response.status === 401) {
+        if (typeof window !== "undefined") {
+            window.location.href = "/login";
+        }
+        alert(data.message);
+    }
+
+    if (response.status === 403) {
+        if (typeof window !== "undefined") {
+            window.location.href = "/error/403";
+        }
+        alert(data.message);
+    }
+
+    if (!response.ok) {
+        throw new Error(data.message || "API 요청 실패");
+    }
+
+    return data;
+}

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -8,9 +8,16 @@ import { redirect } from "next/navigation";
  * @returns {never} This function doesn't return as it triggers a redirect.
  */
 export function encodedRedirect(
-  type: "error" | "success",
-  path: string,
-  message: string,
+    type: "error" | "success",
+    path: string,
+    message: string,
 ) {
-  return redirect(`${path}?${type}=${encodeURIComponent(message)}`);
+    return redirect(`${path}?${type}=${encodeURIComponent(message)}`);
+}
+
+export function getToken() {
+    if (typeof window === "undefined") return null;
+    return localStorage.getItem("auth-storage")
+        ? JSON.parse(localStorage.getItem("auth-storage")!).state.token
+        : null;
 }


### PR DESCRIPTION
## 작업 내용
> ### API 호출 관련 함수 및 커스텀 훅 작성
- `utils/fetcher.ts` : 헤더 토큰 추가, 401, 403 에러 처리 포함한 fetch 함수 작성
  - api 호출 시 해당 파일에서 fetcher를 받아와서 사용하면 됨
  - 예) `fetcher(endpoint, {method : 'POST' , body: {email : ...}})`
- `hooks/useCategories.ts` : SWR을 사용하여 작성. (만약 사용하신다면, 참고하시면 됩니다.)


> ### API 연동 (진행 중)
- 목록 조회, 카테고리 삭제만 연동
- 현재 useCategories를 카테고리 page가 아니라 컴포넌트에서 호출했는데 생각해보니 page.tsx에서 호출해야 할 것 같네요... 이 부분은 내일 수정하겠습니다.

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
