### PR TITLE
[Feat/#150] 오늘의 루틴페이지 일차 계산로직 수정, 체크 후 바로 화면에 적용 안되는 현상 수정, 체크할때 달성률 80% 넘을 시 상태 3으로 80%미만시 상태0으로 수정하는 기능 추가, 리스트 보여줄때 0인것만 보여주는 것에서 3인것도 포함하고 종료일 오늘부터 이후인것만 보여주도록 수정

### DIFF
--- a/app/(base)/member/daily-routine/components/TestHabitList.tsx
+++ b/app/(base)/member/daily-routine/components/TestHabitList.tsx
@@ -86,6 +86,12 @@ export default function HabitList() {
                     ...prev,
                     [habitId]: !isChecked,
                 }));
+
+                await fetch("/api/test-habits/" + habitId + "/auto-status", {
+                    method: "POST",
+                    headers: { Authorization: `Bearer ${token}` },
+                });
+
                 await fetchHabits();
             } else {
                 const data = await res.json();

--- a/app/(base)/member/daily-routine/components/TestHabitList.tsx
+++ b/app/(base)/member/daily-routine/components/TestHabitList.tsx
@@ -12,10 +12,11 @@ type Habit = {
     description: string;
     startAt: string;
     finishedAt: string;
-    daysPassed: number;
+    checkedDays: number;
     totalDays: number;
     rate: string;
     canGiveUp: boolean;
+    daysPassed: number;
 };
 
 export default function HabitList() {
@@ -85,6 +86,7 @@ export default function HabitList() {
                     ...prev,
                     [habitId]: !isChecked,
                 }));
+                await fetchHabits();
             } else {
                 const data = await res.json();
                 alert(data.error || "처리 실패");

--- a/app/api/test-habits/[id]/auto-status/route.ts
+++ b/app/api/test-habits/[id]/auto-status/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SbHabitRepository } from "@/infra/repositories/supabase/SbHabitRepository";
+import { SbHabitRecordRepository } from "@/infra/repositories/supabase/SbHabitRecordRepository";
+import { TestAutoUpdateHabitStatusUsecase } from "@/application/usecase/habit/TestAutoUpdateHabitStatusUsecase";
+
+export async function POST(
+    req: NextRequest,
+    { params }: { params: { id: string } }
+) {
+    try {
+        const habitId = Number(params.id);
+        const usecase = new TestAutoUpdateHabitStatusUsecase(
+            new SbHabitRepository(),
+            new SbHabitRecordRepository()
+        );
+        await usecase.execute(habitId);
+
+        return NextResponse.json({ message: "습관 상태 자동 업데이트 완료" });
+    } catch (error: any) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+}

--- a/application/usecase/habit/TestAutoUpdateHabitStatusUsecase.ts
+++ b/application/usecase/habit/TestAutoUpdateHabitStatusUsecase.ts
@@ -1,0 +1,27 @@
+import { HabitRepository } from "@/domain/repositories/HabitRepository";
+import { HabitRecordRepository } from "@/domain/repositories/HabitRecordRepository";
+
+export class TestAutoUpdateHabitStatusUsecase {
+    constructor(
+        private readonly habitRepo: HabitRepository,
+        private readonly recordRepo: HabitRecordRepository
+    ) { }
+
+    async execute(habitId: number): Promise<void> {
+        const habit = await this.habitRepo.TestFindById(habitId);
+        if (!habit) throw new Error("습관을 찾을 수 없습니다");
+
+        const start = new Date(habit.createdAt);
+        const end = new Date(habit.finishedAt);
+        const totalDays = Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+
+        const checkedCount = await this.recordRepo.TestCountByHabitId(habitId);
+        const rate = (checkedCount / totalDays) * 100;
+
+        const newStatus = rate >= 80 ? 3 : 0;
+
+        if (habit.status !== newStatus) {
+            await this.habitRepo.TestUpdateStatus(habitId, newStatus);
+        }
+    }
+}

--- a/application/usecase/habit/TestGetOngoingHabitsUsecase.ts
+++ b/application/usecase/habit/TestGetOngoingHabitsUsecase.ts
@@ -18,9 +18,10 @@ export class TestGetOngoingHabitsUsecase {
                 const end = new Date(habit.finishedAt);
 
                 const totalDays = Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+                const dayPassed = Math.ceil((today.getTime() - start.getTime()) / (1000 * 60 * 60 * 24));
 
-                const checkedCount = await this.recordRepo.TestCountByHabitId(habit.id);
-                const rate = Math.round((checkedCount / totalDays) * 100);
+                const checkedDays = await this.recordRepo.TestCountByHabitId(habit.id);
+                const rate = Math.round((checkedDays / totalDays) * 100);
 
                 return new TestHabitProgressDto(
                     habit.id,
@@ -30,10 +31,11 @@ export class TestGetOngoingHabitsUsecase {
                     habit.description,
                     start.toISOString().slice(0, 10),
                     end.toISOString().slice(0, 10),
-                    checkedCount,
+                    checkedDays,
                     totalDays,
-                    `${rate}% (${checkedCount}일 / ${totalDays}일)`,
-                    rate < 80
+                    `${rate}% (${checkedDays}일 / ${totalDays}일)`,
+                    rate < 80,
+                    dayPassed
                 );
             })
         );

--- a/application/usecase/habit/dto/TestHabitProgressDto.ts
+++ b/application/usecase/habit/dto/TestHabitProgressDto.ts
@@ -7,9 +7,10 @@ export class TestHabitProgressDto {
         public description: string,
         public startAt: string,
         public finishedAt: string,
-        public daysPassed: number,
+        public checkedDays: number,
         public duration: number,
         public rate: string,
-        public canGiveUp: boolean
+        public canGiveUp: boolean,
+        public daysPassed: number
     ) { }
 }

--- a/domain/repositories/HabitRepository.ts
+++ b/domain/repositories/HabitRepository.ts
@@ -21,4 +21,6 @@ export interface HabitRepository {
         description: string,
         finishedAt: string
     ): Promise<void>;
+    TestFindById(id: number): Promise<Habit>;
+    TestUpdateStatus(habitId: number, status: number): Promise<void>;
 }

--- a/infra/repositories/supabase/SbHabitRepository.ts
+++ b/infra/repositories/supabase/SbHabitRepository.ts
@@ -266,4 +266,44 @@ export class SbHabitRepository implements HabitRepository {
             throw new Error("습관 수정 실패: " + error.message);
         }
     }
+
+    // 습관ID로 습관 조회
+    async TestFindById(habitId: number): Promise<Habit> {
+        const supabase = await createClient();
+
+        const { data, error } = await supabase
+            .from("habit")
+            .select("*")
+            .eq("id", habitId)
+            .single();
+
+        if (error) {
+            throw new Error(`습관 조회 실패: ${error.message}`);
+        }
+
+        return new Habit(
+            data.id,
+            data.category_id,
+            data.member_id,
+            data.name,
+            data.description,
+            new Date(data.created_at),
+            new Date(data.finished_at),
+            data.stopped_at,
+            data.status
+        );
+    }
+
+    // 습관 상태 업데이트
+    async TestUpdateStatus(habitId: number, status: number): Promise<void> {
+        const supabase = await createClient();
+        const { error } = await supabase
+            .from("habit")
+            .update({ status })
+            .eq("id", habitId);
+
+        if (error) {
+            throw new Error("습관 상태 변경 실패: " + error.message);
+        }
+    }
 }

--- a/infra/repositories/supabase/SbHabitRepository.ts
+++ b/infra/repositories/supabase/SbHabitRepository.ts
@@ -183,11 +183,14 @@ export class SbHabitRepository implements HabitRepository {
     async TestFindOngoingByMemberId(memberId: string): Promise<TestHabit[]> {
         const supabase = await createClient();
 
+        const today = new Date().toISOString().split("T")[0]; // 'YYYY-MM-DD' 형식
+
         const { data, error } = await supabase
             .from("habit")
-            .select("*, category(name)") // ← category 테이블에서 name 조인
+            .select("*, category(name)")
             .eq("member_id", memberId)
-            .eq("status", 0);
+            .in("status", [0, 3])
+            .gte("finished_at", today);
 
         if (error) {
             throw new Error(`진행 중인 습관 조회 실패: ${error.message}`);


### PR DESCRIPTION
## 작업 내용
> 일차 오류 계산로직 수정, 체크했을때 바로 화면에 적용 안되는 현상 수정 (세계시, 한국시 조정 필요)
> 오늘의 루틴페이지에서 체크할때 내가 진행중인 습관 달성률이 80%넘으면 status 3으로 변경 달성률이 80%아래로 떨어지면 status 0으로 변경
> 오늘의 루틴페이지에서 내가 진행중인 습관 보여줄때 상태 0인것만 보여주는것에서 3인것도 보여주도록 날짜는 종료일이 오늘부터 이후인것만 보여주도록 수정

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
