### PR TITLE
[fix/#159] 메시지 조회 API 로직 오류 수정

### DIFF
--- a/application/usecase/message/GetMessageListUsecase.ts
+++ b/application/usecase/message/GetMessageListUsecase.ts
@@ -38,7 +38,7 @@ export class GetMessageListUsecase {
 
             // data query
             const filter = new MessageFilter(
-                memberId,
+                mine ? memberId : null,
                 "createdAt",
                 false, // default sorting order: latest first
                 offset,


### PR DESCRIPTION
## 작업 내용
Usecase에서 mine 옵션값에 관계 없이 memberId로 필터를 세팅하던 오류 수정
> 작업 이미지 (FE 경우)

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
