### PR TITLE
[fix/#187] 메시지 폼 유저 정보 API에서 가져오게 변경

### DIFF
--- a/app/(base)/member/message/components/MessageForm.tsx
+++ b/app/(base)/member/message/components/MessageForm.tsx
@@ -12,17 +12,38 @@ type MessageFormProps = {
 };
 
 export default function MessageForm(props: MessageFormProps) {
+    const contentMaxLength: number = 100;
+    const defaultProfileImageUrl: string = "/images/ProfileCircle.png";
+
     const submitButtonName: string =
         props.messageDto === null ? "등록" : "수정";
     const defaultContent: string =
         props.messageDto === null ? "" : props.messageDto.content;
 
-    const { user } = useAuthStore();
+    const { token } = useAuthStore();
+    const [nickname, setNickname] = useState<string>("");
+    const [imageUrl, setImageUrl] = useState<string>(defaultProfileImageUrl);
+
+    const getMemberInfo = async () => {
+        const res = await fetch("/api/members/profile", {
+            method: "GET",
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        });
+
+        const member = await res.json();
+
+        if (res.ok) {
+            setNickname(member.nickname);
+            setImageUrl(member.imageUrl);
+        }
+    };
+
+    getMemberInfo();
+
     const [content, setContent] = useState<string>(defaultContent);
     const [wordCount, setWordCount] = useState<number>(0);
-
-    const contentMaxLength: number = 100;
-    const defaultProfileImageUrl: string = "/images/ProfileCircle.png";
 
     const handleChange = async (element: ChangeEvent<HTMLInputElement>) => {
         if (element.target.value.length > contentMaxLength) {
@@ -42,13 +63,13 @@ export default function MessageForm(props: MessageFormProps) {
         <div className={styles.wrapper}>
             <nav className={styles.nav}>
                 <Image
-                    src={user?.imageUrl || defaultProfileImageUrl}
+                    src={imageUrl || defaultProfileImageUrl}
                     alt="프로필 이미지"
                     width={40}
                     height={40}
                     className="w-8 h-8 rounded-full"
                 />
-                <div className="text-sm font-semibold">{user?.nickname}</div>
+                <div className="text-sm font-semibold">{nickname}</div>
             </nav>
             <input
                 type="text"


### PR DESCRIPTION
## 작업 내용
작성자 닉네임/프로필 사진 정보 받아오는 과정 useAuthStore->API 호출로 변경
> 작업 이미지 (FE 경우)

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
