### PR TITLE
[feat/#204] 기록보기 페이지

### DIFF
--- a/app/(base)/member/record/components/TestRecordList.module.scss
+++ b/app/(base)/member/record/components/TestRecordList.module.scss
@@ -1,0 +1,109 @@
+.container {
+    max-width: 768px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 40px 16px;
+    font-family: 'Pretendard', sans-serif;
+}
+
+.habitList {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.habitCard {
+    display: flex;
+    align-items: center;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--color-gray);
+    gap: 12px;
+    font-size: var(--fontSize-md);
+
+    .category {
+        min-width: 80px;
+        font-weight: var(--fontWeight-bold);
+        text-align: center;
+        padding: 8px;
+        background-color: var(--color-main2);
+    }
+
+    .info {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        flex-direction: column;
+
+        .title {
+            font-weight: var(--fontWeight-semiBold);
+            font-size: var(--fontSize-md);
+        }
+
+        .desc {
+            color: var(--color-darkGray);
+            font-size: var(--fontSize-md);
+        }
+
+        .progress {
+            font-size: var(--fontSize-md);
+            color: var(--color-darkGray);
+        }
+    }
+}
+
+.tabs {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+
+    button {
+        padding: 0.5rem 1rem;
+        border: 1px solid var(--color-main2);
+        background-color: var(--color-main2);
+        cursor: pointer;
+    }
+
+    .activeTab {
+        background-color: var(--color-main1);
+        color: white;
+        font-weight: var(--fontWeight-bold);
+    }
+}
+
+.headerRow {
+    display: flex;
+    align-items: center;
+    padding: 8px 16px;
+    font-size: var(--fontSize-md);
+    font-weight: var(--fontWeight-bold);
+
+    .category {
+        min-width: 80px;
+
+        select {
+            min-width: 80px;
+            padding: 8px;
+            border: 1px solid var(--color-gray);
+
+            &:focus {
+                outline: none;
+                border-color: var(--color-main1);
+                box-shadow: 0 0 0 2px rgba(64, 183, 223, 0.3);
+            }
+        }
+    }
+
+    .info {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        .title {
+            font-size: var(--fontSize-sm);
+            font-weight: var(--fontWeight-bold);
+            color: var(--color-black);
+        }
+    }
+}

--- a/app/(base)/member/record/components/TestRecordList.tsx
+++ b/app/(base)/member/record/components/TestRecordList.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useAuthStore } from "@/stores/authStore";
+import { useEffect, useState, useCallback } from "react";
+import styles from "./TestRecordList.module.scss";
+import Loading from "@/app/components/Loading";
+
+type Habit = {
+    id: number;
+    categoryId: string;
+    categoryName: string;
+    name: string;
+    description: string;
+    startAt: string;
+    finishedAt: string;
+    stoppedAt: string;
+    duration: number;
+    rate: string;
+};
+
+export default function TestRecordList() {
+    const [habits, setHabits] = useState<Habit[]>([]);
+    const [categories, setCategories] = useState<{ id: number; name: string }[]>([]);
+    const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [statusTab, setStatusTab] = useState<"success" | "giveup" | "fail">("success");
+
+    const token = useAuthStore.getState().token;
+
+    // 오늘 날짜 (YYYY-MM-DD)
+    const today = new Date().toISOString().slice(0, 10);
+
+    const fetchHabits = useCallback(async () => {
+        try {
+            setIsLoading(true);
+            let url = "/api/test-habits/success/";
+
+            if (statusTab === "giveup") {
+                url = "/api/test-habits/giveup/";
+            } else if (statusTab === "fail") {
+                url = "/api/test-habits/fail/";
+            }
+            const res = await fetch(url, {
+                method: "GET",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+            });
+            const data = await res.json();
+            const habits = Array.isArray(data) ? data : data.habits;
+            setHabits(habits);
+        } catch (error) {
+            console.error("불러오기 실패:", error);
+        } finally {
+            setIsLoading(false);
+        }
+    }, [token, statusTab]);
+
+    useEffect(() => {
+        const fetchCategories = async () => {
+            try {
+                const res = await fetch("/api/categories");
+                const data = await res.json();
+                if (Array.isArray(data.categories)) {
+                    setCategories(data.categories);
+                }
+            } catch (error) {
+                console.error("카테고리 불러오기 실패:", error);
+            }
+        };
+        fetchCategories();
+    }, []);
+
+    useEffect(() => {
+        fetchHabits();
+    }, [fetchHabits]);
+
+    if (isLoading) {
+        return <Loading />;
+    }
+
+    return (
+        <div className={styles.container}>
+            <div className={styles.tabs}>
+                <button
+                    className={statusTab === "success" ? styles.activeTab : ""}
+                    onClick={() => setStatusTab("success")}
+                >
+                    달성
+                </button>
+                <button
+                    className={statusTab === "fail" ? styles.activeTab : ""}
+                    onClick={() => setStatusTab("fail")}
+                >
+                    실패
+                </button>
+                <button
+                    className={statusTab === "giveup" ? styles.activeTab : ""}
+                    onClick={() => setStatusTab("giveup")}
+                >
+                    포기
+                </button>
+            </div>
+            <div className={styles.headerRow}>
+                <div className={styles.category}>
+                    <select
+                        value={selectedCategoryId ?? ""}
+                        onChange={(e) =>
+                            setSelectedCategoryId(e.target.value === "" ? null : Number(e.target.value))
+                        }
+                    >
+                        <option value="">전체</option>
+                        {categories.map((cat) => (
+                            <option key={cat.id} value={cat.id}>
+                                {cat.name}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <div className={styles.info}><div className={styles.title}>습관명</div></div>
+                <div className={styles.info}><div className={styles.title}>설명</div></div>
+                <div className={styles.info}><div className={styles.title}>시작일</div></div>
+                <div className={styles.info}><div className={styles.title}>종료일</div></div>
+                <div className={styles.info}><div className={styles.title}>포기일</div></div>
+                <div className={styles.info}><div className={styles.title}>기간</div></div>
+                <div className={styles.info}><div className={styles.title}>달성률</div></div>
+            </div>
+            <div className={styles.habitList}>
+                {habits
+                    .filter(
+                        (habit) => selectedCategoryId === null || Number(habit.categoryId) === selectedCategoryId
+                    )
+                    .map((habit) => (
+                        <div className={styles.habitCard} key={habit.id}>
+                            <div className={styles.category}>{habit.categoryName}</div>
+                            <div className={styles.info}>
+                                <div className={styles.title}>{habit.name}</div>
+                            </div>
+                            <div className={styles.info}>
+                                <div className={styles.desc}>{habit.description}</div>
+                            </div>
+                            <div className={styles.info}>
+                                <div className={styles.desc}>{habit.startAt}</div>
+                            </div>
+                            <div className={styles.info}>
+                                <div className={styles.desc}>{habit.finishedAt}</div>
+                            </div>
+                            <div className={styles.info}>
+                                <div className={styles.desc}>{habit.stoppedAt ? habit.stoppedAt : "-"}</div>
+                            </div>
+                            <div className={styles.info}>
+                                <div className={styles.desc}>{habit.duration}일</div>
+                            </div>
+                            <div className={styles.info}>
+                                <div className={styles.progress}>
+                                    {habit.rate}
+                                </div>
+                            </div>
+                        </div>
+                    ))}
+            </div>
+        </div>
+    );
+}

--- a/app/(base)/member/record/page.tsx
+++ b/app/(base)/member/record/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+import React from "react";
+import TestRecordList from "./components/TestRecordList";
+
+export default function page() {
+    return (
+        <>
+            {/* <TestRecordList /> */}
+        </>
+    );
+}

--- a/app/api/test-habits/fail/route.ts
+++ b/app/api/test-habits/fail/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SbHabitRepository } from "@/infra/repositories/supabase/SbHabitRepository";
+import { getMemberIdFromToken } from "@/utils/auth";
+import { SbHabitRecordRepository } from "@/infra/repositories/supabase/SbHabitRecordRepository";
+import { TestGetFailHabitsUsecase } from "@/application/usecase/habit/TestGetFailHabitsUsecase";
+
+export async function GET(req: NextRequest) {
+    try {
+        const authHeader = req.headers.get("authorization");
+        const memberId = await getMemberIdFromToken(authHeader!);
+        const habitRepo = new SbHabitRepository();
+        const recordRepo = new SbHabitRecordRepository();
+        const usecase = new TestGetFailHabitsUsecase(habitRepo, recordRepo);
+        const habits = await usecase.execute(memberId!);
+
+        return NextResponse.json({ habits });
+    } catch (error: any) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+}

--- a/app/api/test-habits/giveup/route.ts
+++ b/app/api/test-habits/giveup/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SbHabitRepository } from "@/infra/repositories/supabase/SbHabitRepository";
+import { getMemberIdFromToken } from "@/utils/auth";
+import { SbHabitRecordRepository } from "@/infra/repositories/supabase/SbHabitRecordRepository";
+import { TestGetGiveupHabitsUsecase } from "@/application/usecase/habit/TestGetGiveupHabitsUsecase";
+
+export async function GET(req: NextRequest) {
+    try {
+        const authHeader = req.headers.get("authorization");
+        const memberId = await getMemberIdFromToken(authHeader!);
+        const habitRepo = new SbHabitRepository();
+        const recordRepo = new SbHabitRecordRepository();
+        const usecase = new TestGetGiveupHabitsUsecase(habitRepo, recordRepo);
+        const habits = await usecase.execute(memberId!);
+
+        return NextResponse.json({ habits });
+    } catch (error: any) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+}

--- a/app/api/test-habits/success/route.ts
+++ b/app/api/test-habits/success/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SbHabitRepository } from "@/infra/repositories/supabase/SbHabitRepository";
+import { getMemberIdFromToken } from "@/utils/auth";
+import { SbHabitRecordRepository } from "@/infra/repositories/supabase/SbHabitRecordRepository";
+import { TestGetSuccessHabitsUsecase } from "@/application/usecase/habit/TestGetSuccessHabitsUsecase";
+
+export async function GET(req: NextRequest) {
+    try {
+        const authHeader = req.headers.get("authorization");
+        const memberId = await getMemberIdFromToken(authHeader!);
+        const habitRepo = new SbHabitRepository();
+        const recordRepo = new SbHabitRecordRepository();
+        const usecase = new TestGetSuccessHabitsUsecase(habitRepo, recordRepo);
+        const habits = await usecase.execute(memberId!);
+
+        return NextResponse.json({ habits });
+    } catch (error: any) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+}

--- a/application/usecase/habit/TestGetFailHabitsUsecase.ts
+++ b/application/usecase/habit/TestGetFailHabitsUsecase.ts
@@ -1,0 +1,38 @@
+import { HabitRecordRepository } from "@/domain/repositories/HabitRecordRepository";
+import { HabitRepository } from "@/domain/repositories/HabitRepository";
+import { TestHabitReadRecordDto } from "./dto/TestHabitReadRecordDto";
+
+export class TestGetFailHabitsUsecase {
+    constructor(
+        private readonly habitRepo: HabitRepository,
+        private readonly recordRepo: HabitRecordRepository
+    ) { }
+
+    async execute(memberId: string): Promise<TestHabitReadRecordDto[]> {
+        const habits = await this.habitRepo.TestFindFailByMemberId(memberId);
+
+        return await Promise.all(
+            habits.map(async (habit) => {
+                const start = new Date(habit.createdAt);
+                const end = new Date(habit.finishedAt);
+                const giveUp = habit.stoppedAt ? new Date(habit.stoppedAt) : null;
+                const totalDays = Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+                const checkedDays = await this.recordRepo.TestCountByHabitId(habit.id);
+                const rate = Math.round((checkedDays / totalDays) * 100);
+
+                return new TestHabitReadRecordDto(
+                    habit.id,
+                    habit.categoryId,
+                    habit.categoryName ?? "",
+                    habit.name,
+                    habit.description,
+                    start.toISOString().slice(0, 10),
+                    end.toISOString().slice(0, 10),
+                    giveUp ? giveUp.toISOString().slice(0, 10) : null,
+                    totalDays,
+                    `${rate}% `,
+                );
+            })
+        );
+    }
+}

--- a/application/usecase/habit/TestGetGiveupHabitsUsecase.ts
+++ b/application/usecase/habit/TestGetGiveupHabitsUsecase.ts
@@ -1,0 +1,38 @@
+import { HabitRecordRepository } from "@/domain/repositories/HabitRecordRepository";
+import { HabitRepository } from "@/domain/repositories/HabitRepository";
+import { TestHabitReadRecordDto } from "./dto/TestHabitReadRecordDto";
+
+export class TestGetGiveupHabitsUsecase {
+    constructor(
+        private readonly habitRepo: HabitRepository,
+        private readonly recordRepo: HabitRecordRepository
+    ) { }
+
+    async execute(memberId: string): Promise<TestHabitReadRecordDto[]> {
+        const habits = await this.habitRepo.TestFindGiveupByMemberId(memberId);
+
+        return await Promise.all(
+            habits.map(async (habit) => {
+                const start = new Date(habit.createdAt);
+                const end = new Date(habit.finishedAt);
+                const giveUp = habit.stoppedAt ? new Date(habit.stoppedAt) : null;
+                const totalDays = Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+                const checkedDays = await this.recordRepo.TestCountByHabitId(habit.id);
+                const rate = Math.round((checkedDays / totalDays) * 100);
+
+                return new TestHabitReadRecordDto(
+                    habit.id,
+                    habit.categoryId,
+                    habit.categoryName ?? "",
+                    habit.name,
+                    habit.description,
+                    start.toISOString().slice(0, 10),
+                    end.toISOString().slice(0, 10),
+                    giveUp ? giveUp.toISOString().slice(0, 10) : null,
+                    totalDays,
+                    `${rate}% `,
+                );
+            })
+        );
+    }
+}

--- a/application/usecase/habit/TestGetSuccessHabitsUsecase.ts
+++ b/application/usecase/habit/TestGetSuccessHabitsUsecase.ts
@@ -1,0 +1,38 @@
+import { HabitRecordRepository } from "@/domain/repositories/HabitRecordRepository";
+import { HabitRepository } from "@/domain/repositories/HabitRepository";
+import { TestHabitReadRecordDto } from "./dto/TestHabitReadRecordDto";
+
+export class TestGetSuccessHabitsUsecase {
+    constructor(
+        private readonly habitRepo: HabitRepository,
+        private readonly recordRepo: HabitRecordRepository
+    ) { }
+
+    async execute(memberId: string): Promise<TestHabitReadRecordDto[]> {
+        const habits = await this.habitRepo.TestFindSuccessByMemberId(memberId);
+
+        return await Promise.all(
+            habits.map(async (habit) => {
+                const start = new Date(habit.createdAt);
+                const end = new Date(habit.finishedAt);
+                const giveUp = habit.stoppedAt ? new Date(habit.stoppedAt) : null;
+                const totalDays = Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+                const checkedDays = await this.recordRepo.TestCountByHabitId(habit.id);
+                const rate = Math.round((checkedDays / totalDays) * 100);
+
+                return new TestHabitReadRecordDto(
+                    habit.id,
+                    habit.categoryId,
+                    habit.categoryName ?? "",
+                    habit.name,
+                    habit.description,
+                    start.toISOString().slice(0, 10),
+                    end.toISOString().slice(0, 10),
+                    giveUp ? giveUp.toISOString().slice(0, 10) : null,
+                    totalDays,
+                    `${rate}% `,
+                );
+            })
+        );
+    }
+}

--- a/application/usecase/habit/dto/TestHabitReadRecordDto.ts
+++ b/application/usecase/habit/dto/TestHabitReadRecordDto.ts
@@ -1,0 +1,14 @@
+export class TestHabitReadRecordDto {
+    constructor(
+        public id: number,
+        public categoryId: number,
+        public categoryName: string,
+        public name: string,
+        public description: string,
+        public startAt: string,
+        public finishedAt: string,
+        public stoppedAt: string | null,
+        public duration: number,
+        public rate: string,
+    ) { }
+}

--- a/domain/repositories/HabitRepository.ts
+++ b/domain/repositories/HabitRepository.ts
@@ -25,4 +25,7 @@ export interface HabitRepository {
     ): Promise<void>;
     TestFindById(id: number): Promise<Habit>;
     TestUpdateStatus(habitId: number, status: number): Promise<void>;
+    TestFindSuccessByMemberId(memberId: string): Promise<TestHabit[]>;
+    TestFindGiveupByMemberId(memberId: string): Promise<TestHabit[]>;
+    TestFindFailByMemberId(memberId: string): Promise<TestHabit[]>;
 }

--- a/infra/repositories/supabase/SbHabitRepository.ts
+++ b/infra/repositories/supabase/SbHabitRepository.ts
@@ -321,4 +321,105 @@ export class SbHabitRepository implements HabitRepository {
             throw new Error("습관 상태 변경 실패: " + error.message);
         }
     }
+
+    // 습관 조회 (달성한 습관)
+    async TestFindSuccessByMemberId(memberId: string): Promise<TestHabit[]> {
+        const supabase = await createClient();
+
+        const today = new Date().toISOString().split("T")[0]; // 'YYYY-MM-DD' 형식
+
+        const { data, error } = await supabase
+            .from("habit")
+            .select("*, category(name)")
+            .eq("member_id", memberId)
+            .in("status", [3])
+            .lt("finished_at", today);
+
+        if (error) {
+            throw new Error(`달성한 습관 조회 실패: ${error.message}`);
+        }
+
+        return data.map(
+            (item) =>
+                new TestHabit(
+                    item.id,
+                    item.category_id,
+                    item.member_id,
+                    item.name,
+                    item.description,
+                    new Date(item.created_at),
+                    new Date(item.finished_at),
+                    item.stopped_at ? new Date(item.stopped_at) : null,
+                    item.status,
+                    item.category.name,
+                ),
+        );
+    }
+
+    // 습관 조회 (포기한 습관)
+    async TestFindGiveupByMemberId(memberId: string): Promise<TestHabit[]> {
+        const supabase = await createClient();
+
+        const today = new Date().toISOString().split("T")[0]; // 'YYYY-MM-DD' 형식
+
+        const { data, error } = await supabase
+            .from("habit")
+            .select("*, category(name)")
+            .eq("member_id", memberId)
+            .in("status", [2])
+
+        if (error) {
+            throw new Error(`포기한 습관 조회 실패: ${error.message}`);
+        }
+
+        return data.map(
+            (item) =>
+                new TestHabit(
+                    item.id,
+                    item.category_id,
+                    item.member_id,
+                    item.name,
+                    item.description,
+                    new Date(item.created_at),
+                    new Date(item.finished_at),
+                    item.stopped_at ? new Date(item.stopped_at) : null,
+                    item.status,
+                    item.category.name,
+                ),
+        );
+    }
+
+    // 습관 조회 (실패한 습관)
+    async TestFindFailByMemberId(memberId: string): Promise<TestHabit[]> {
+        const supabase = await createClient();
+
+        const today = new Date().toISOString().split("T")[0]; // 'YYYY-MM-DD' 형식
+
+        const { data, error } = await supabase
+            .from("habit")
+            .select("*, category(name)")
+            .eq("member_id", memberId)
+            .in("status", [0])
+            .lt("finished_at", today);
+
+        if (error) {
+            throw new Error(`실패한 습관 조회 실패: ${error.message}`);
+        }
+
+        return data.map(
+            (item) =>
+                new TestHabit(
+                    item.id,
+                    item.category_id,
+                    item.member_id,
+                    item.name,
+                    item.description,
+                    new Date(item.created_at),
+                    new Date(item.finished_at),
+                    item.stopped_at ? new Date(item.stopped_at) : null,
+                    item.status,
+                    item.category.name,
+                ),
+        );
+    }
 }


### PR DESCRIPTION
## 작업 내용
> 기록보기 페이지
> 작업 이미지 (FE 경우)
![포기](https://github.com/user-attachments/assets/70c9eaee-1357-46cb-8048-7dc16fe56b08)
![실패](https://github.com/user-attachments/assets/fc30b843-4d5b-4379-ac10-e5f29e0f3b2c)
![달성](https://github.com/user-attachments/assets/17da7f0a-1dff-47f9-a253-89b8215afdab)


## 리뷰 요구사항 (선택)
> 실패 처리 방법 바꿧음 기존 오늘의루틴페이지에서 날짜가 지났을때 상태변경하는 로직 없고 자동으로 바꿔줄수도 없음
그래서 실패는 상태가 0인것중에 종료일이 오늘 이전인 것을 추려야함
page.tsx에 컴포넌트 주석처리 해놨는데 건님이 못하시면 주석 풀고 쓰면 됨
