### PR TITLE
[feat/#237] 회원가입페이지, 마이페이지, 비밀번호변경페이지에서 알림창 토스트로 수정하기

### DIFF
--- a/app/(auth)/signup/components/SignUpForm.tsx
+++ b/app/(auth)/signup/components/SignUpForm.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import styles from "./SignUpForm.module.scss";
+import { useToastStore } from "@/stores/toastStore";
 
 export function SignUpForm() {
     const router = useRouter();
@@ -28,7 +29,7 @@ export function SignUpForm() {
     // 이메일 중복 검사
     const handleEmailCheck = async () => {
         if (!email) {
-            alert("이메일을 입력해주세요.");
+            useToastStore.getState().show("이메일을 입력해주세요.");
             return;
         }
 
@@ -49,7 +50,7 @@ export function SignUpForm() {
             setEmailError("이미 사용 중인 이메일입니다.");
             setIsEmailChecked(false);
         } else {
-            alert("사용 가능한 이메일입니다.");
+            useToastStore.getState().show("사용 가능한 이메일입니다.");
             setEmailError("");
             setIsEmailChecked(true);
         }
@@ -103,22 +104,22 @@ export function SignUpForm() {
         e.preventDefault();
 
         if (!name || !email || !password || !nickname) {
-            alert("모든 필드를 입력해주세요.");
+            useToastStore.getState().show("모든 필드를 입력해주세요.");
             return;
         }
 
         if (emailError || passwordError) {
-            alert("입력한 정보가 올바르지 않습니다.");
+            useToastStore.getState().show("입력한 정보가 올바르지 않습니다.");
             return;
         }
 
         if (!isEmailChecked) {
-            alert("이메일 중복 확인을 완료해주세요.");
+            useToastStore.getState().show("이메일 중복 확인을 완료해주세요.");
             return;
         }
 
         if (confirmPassword !== password) {
-            alert("비밀번호가 일치하지 않습니다.");
+            useToastStore.getState().show("비밀번호가 일치하지 않습니다.");
             return;
         }
 

--- a/app/(base)/member/profile/components/ProfileForm.tsx
+++ b/app/(base)/member/profile/components/ProfileForm.tsx
@@ -3,6 +3,7 @@ import { useRef, useState } from "react";
 import Image from "next/image";
 import styles from "./ProfileForm.module.scss";
 import { useAuthStore } from "@/stores/authStore";
+import { useToastStore } from "@/stores/toastStore";
 
 type Props = {
     profile: {
@@ -46,12 +47,12 @@ export default function ProfileForm({ profile }: Props) {
 
     const handleSubmit = async () => {
         if (!password) {
-            alert("비밀번호를 입력해주세요.");
+            useToastStore.getState().show("비밀번호를 입력해주세요.");
             return;
         }
 
         if (!nickname.trim()) {
-            alert("닉네임을 입력해주세요.");
+            useToastStore.getState().show("닉네임을 입력해주세요.");
             return;
         }
 
@@ -69,7 +70,7 @@ export default function ProfileForm({ profile }: Props) {
         const passwordData = await passwordRes.json();
 
         if (!passwordRes.ok || !passwordData.valid) {
-            alert("비밀번호가 틀렸습니다. 다시 입력해주세요.");
+            useToastStore.getState().show("비밀번호가 틀렸습니다. 다시 입력해주세요.");
             return;
         }
 
@@ -93,10 +94,12 @@ export default function ProfileForm({ profile }: Props) {
             if (data.imageUrl) {
                 setPreview(data.imageUrl);
             }
-            alert("프로필이 성공적으로 변경되었습니다.");
+            useToastStore.getState().show("프로필이 성공적으로 변경되었습니다.");
             setPassword("");
         } else {
-            alert(data.error || "프로필 업데이트 실패");
+            useToastStore.getState().show(
+                data.error || "프로필 업데이트 실패"
+            );
         }
     };
 

--- a/app/(base)/member/profile/components/WithdrawButton.tsx
+++ b/app/(base)/member/profile/components/WithdrawButton.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import styles from "./WithdrawButton.module.scss";
 import { useAuthStore } from "@/stores/authStore";
+import { useToastStore } from "@/stores/toastStore";
 
 export default function WithdrawButton() {
     const router = useRouter();
@@ -24,11 +25,13 @@ export default function WithdrawButton() {
 
         if (res.ok) {
             logout();
-            alert("탈퇴가 완료되었습니다.");
+            useToastStore.getState().show("탈퇴가 완료되었습니다.");
             router.push("/login");
         } else {
             const data = await res.json();
-            alert(data.error || "탈퇴 실패");
+            useToastStore.getState().show(
+                data.error || "탈퇴 실패"
+            );
         }
     };
 

--- a/app/(base)/member/profile/password-change/components/PasswordChangeForm.tsx
+++ b/app/(base)/member/profile/password-change/components/PasswordChangeForm.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthStore } from "@/stores/authStore";
 import styles from "./PasswordChangeForm.module.scss";
+import { useToastStore } from "@/stores/toastStore";
 
 export default function PasswordChangeForm() {
     const router = useRouter();
@@ -26,23 +27,23 @@ export default function PasswordChangeForm() {
 
     const handleSubmit = async () => {
         if (!currentPassword || !newPassword || !confirmPassword) {
-            alert("모든 비밀번호를 입력해주세요.");
+            useToastStore.getState().show("모든 비밀번호를 입력해주세요.");
             return;
         }
 
         if (passwordError) {
-            alert(passwordError);
+            useToastStore.getState().show(passwordError);
             return;
         }
 
         if (newPassword !== confirmPassword) {
-            alert("새 비밀번호가 일치하지 않습니다.");
+            useToastStore.getState().show("새 비밀번호가 일치하지 않습니다.");
             return;
         }
 
         const token = useAuthStore.getState().token;
         if (!token) {
-            alert("로그인이 필요합니다.");
+            useToastStore.getState().show("로그인이 필요합니다.");
             return;
         }
 
@@ -58,7 +59,7 @@ export default function PasswordChangeForm() {
 
         const verifyData = await verifyRes.json();
         if (!verifyRes.ok || !verifyData.valid) {
-            alert("비밀번호가 틀렸습니다. 다시 입력해주세요.");
+            useToastStore.getState().show("비밀번호가 틀렸습니다. 다시 입력해주세요.");
             return;
         }
 
@@ -73,11 +74,13 @@ export default function PasswordChangeForm() {
         });
 
         if (changeRes.ok) {
-            alert("비밀번호가 성공적으로 변경되었습니다.");
+            useToastStore.getState().show("비밀번호가 성공적으로 변경되었습니다.");
             router.push("/member/profile");
         } else {
             const data = await changeRes.json();
-            alert(data.error || "비밀번호 변경에 실패했습니다.");
+            useToastStore.getState().show(
+                data.error || "비밀번호 변경에 실패했습니다."
+            );
         }
     };
 

--- a/app/admin/components/CategoryModal.tsx
+++ b/app/admin/components/CategoryModal.tsx
@@ -4,6 +4,7 @@ import ModalWrapper from "@/app/components/ModalWrapper";
 import useModalStore from "@/stores/modalStore";
 import React, { ChangeEvent, FormEvent, useState } from "react";
 import styles from "./CategoryModal.module.scss";
+import { useToastStore } from "@/stores/toastStore";
 
 type CategoryModalProps = {
     type: "create" | "edit";
@@ -23,7 +24,7 @@ export default function CategoryModal({
     const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         if (!input) {
-            alert("카테고리 이름을 입력해주세요."); // 추후 토스트로 처리
+            useToastStore.getState().show("카테고리 이름을 입력해주세요.");
             return;
         }
 


### PR DESCRIPTION
## 작업 내용
> 회원가입페이지, 마이페이지, 비밀번호변경페이지에서 알림창 토스트로 수정하기
> 작업 이미지 (FE 경우)
![회원가입](https://github.com/user-attachments/assets/a0d78314-2d04-47bb-888e-f862c3120402)
![로그인페이지](https://github.com/user-attachments/assets/7ebe4544-9e47-4fc4-b150-828048d08734)
![마이페이지](https://github.com/user-attachments/assets/08af74cc-05c8-44fe-93d9-59440457146a)
![비밀번호변경페이지](https://github.com/user-attachments/assets/7530fdfe-6776-44c6-b1a8-ad087f80108f)

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성

closes #237 
