### PR TITLE
[feat/#239] 기록보기 페이지 밑에 달성/포기/실패 습관 갯수 추가

### DIFF
--- a/app/(base)/member/record/components/TestRecordList.module.scss
+++ b/app/(base)/member/record/components/TestRecordList.module.scss
@@ -125,3 +125,26 @@
         opacity: 0.6;
     }
 }
+
+.celebrate {
+    margin-top: 4rem;
+    text-align: center;
+
+    img {
+        display: block;
+        margin: 0 auto 1rem;
+        max-width: 180px;
+        opacity: 0.9;
+    }
+
+    p {
+        font-size: var(--fontSize-lg);
+        color: var(--color-black);
+        line-height: 1.6;
+
+        strong {
+            font-weight: var(--fontWeight-bold);
+            color: var(--color-main1);
+        }
+    }
+}

--- a/app/(base)/member/record/components/TestRecordList.tsx
+++ b/app/(base)/member/record/components/TestRecordList.tsx
@@ -76,6 +76,10 @@ export default function TestRecordList() {
         fetchHabits();
     }, [fetchHabits]);
 
+    const filteredHabits = habits.filter(
+        (habit) => selectedCategoryId === null || Number(habit.categoryId) === selectedCategoryId
+    );
+
     if (isLoading) {
         return <Loading />;
     }
@@ -210,6 +214,51 @@ export default function TestRecordList() {
                         ))
                 )}
             </div>
+            {statusTab === "success" && filteredHabits.length > 0 && (
+                <div className={styles.celebrate}>
+                    <Image
+                        src="/images/Praise.png"
+                        alt="칭찬 캐릭터"
+                        width={160}
+                        height={160}
+                    />
+                    <p>
+                        <strong>{filteredHabits.length}개의 습관</strong>을 만드셨군요!
+                        <br />
+                        잘하고 있어요 :)
+                    </p>
+                </div>
+            )}
+
+            {statusTab === "fail" && filteredHabits.length > 0 && (
+                <div className={styles.celebrate}>
+                    <Image
+                        src="/images/Together.png"
+                        alt="응원 캐릭터"
+                        width={160}
+                        height={160}
+                    />
+                    <p>
+                        <strong>{filteredHabits.length}개의 습관</strong>을 실패하셨어요.<br />
+                        다시 도전해볼까요?
+                    </p>
+                </div>
+            )}
+
+            {statusTab === "giveup" && filteredHabits.length > 0 && (
+                <div className={styles.celebrate}>
+                    <Image
+                        src="/images/Together.png"
+                        alt="응원 캐릭터"
+                        width={160}
+                        height={160}
+                    />
+                    <p>
+                        <strong>{filteredHabits.length}개의 습관</strong>을 실패하셨어요.<br />
+                        다시 도전해볼까요?
+                    </p>
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## 작업 내용
> 기록보기 페이지 밑에 달성/포기/실패 습관 갯수 추가
> 작업 이미지 (FE 경우)
![달성](https://github.com/user-attachments/assets/c760de2e-af92-49b1-8b91-1935aa3c7f1d)
![포기](https://github.com/user-attachments/assets/b1de9370-0754-4681-aba0-88c1548ca34f)
![실패](https://github.com/user-attachments/assets/081bafd7-8248-497a-a4c8-cf91ed720b14)

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성

closes #239 