### PR TITLE
[Feat/#245] 로딩 이미지 먼저 불러와서 렌더링 속도 개선, 404 페이지 안에 멘트 수정

### DIFF
--- a/app/components/Loading.tsx
+++ b/app/components/Loading.tsx
@@ -12,6 +12,7 @@ export default function Loading() {
                 width={140}
                 height={140}
                 className={styles.image}
+                priority // Next.js가 이 이미지를 가장 먼저 preload하게 해줘서 렌더링 속도를 개선
             />
             <div className={styles.text}>Loading...</div>
         </div>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -12,8 +12,8 @@ export default function NotFound() {
                 height={140}
                 className={styles.image}
             />
-            <h1 className={styles.title}>404 - Forbidden</h1>
-            <p className={styles.message}>죄송합니다. 이 페이지에 접근할 권한이 없습니다.</p>
+            <h1 className={styles.title}>404 - Not Found</h1>
+            <p className={styles.message}>페이지가 존재하지 않습니다.</p>
             <Link href="/" className={styles.link}>
                 홈으로 돌아가기
             </Link>


### PR DESCRIPTION
## 작업 내용
> 로딩 이미지 먼저 불러와서 렌더링 속도 개선
> 404 페이지 안에 멘트 수정
> 작업 이미지 (FE 경우)
![20250425095257](https://github.com/user-attachments/assets/188eb92e-efb1-450d-a8a8-bb2b7edf2ad3)

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성

Closes #245 