### PR TITLE
[feat/#264] 오늘의루틴페이지에서 포기,수정 버튼 전체 기간 중 80%가 되면 안보여야 하는데 달성률이 80%가 되면 안보이게 되서 해당 부분 수정

### DIFF
--- a/application/usecase/habit/GetOngoingHabitsUsecase.ts
+++ b/application/usecase/habit/GetOngoingHabitsUsecase.ts
@@ -26,7 +26,8 @@ export class GetOngoingHabitsUsecase {
                 const dayPassed = Math.ceil(
                     (getMidnight(today).getTime() - getMidnight(start).getTime()) / (1000 * 60 * 60 * 24) + 1
                 );
-
+                const daysTo80Percent = Math.floor(totalDays * 0.8);
+                const canGiveUp = dayPassed <= daysTo80Percent;
                 const checkedDays = await this.recordRepo.countByHabitId(habit.id);
                 const rate = Math.round((checkedDays / totalDays) * 100);
 
@@ -41,7 +42,7 @@ export class GetOngoingHabitsUsecase {
                     checkedDays,
                     totalDays,
                     `${rate}% (${checkedDays}일 / ${totalDays}일)`,
-                    rate < 80,
+                    canGiveUp,
                     dayPassed
                 );
             })


### PR DESCRIPTION
[feat/#264] 오늘의루틴페이지에서 포기,수정 버튼 전체 기간 중 80%가 되면 안보여야 하는데 달성률이 80%가 되면 안보이게 되서 해당 부분 수정

## 작업 내용
> 오늘의루틴페이지에서 포기,수정 버튼 전체 기간 중 80%가 되면 안보여야 하는데 달성률이 80%가 되면 안보이게 되서 해당 부분 수정
> 작업 이미지 (FE 경우)

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성

closes #264 