### PR TITLE
[fix/#272] 카테고리 이름 중복 시 에러 핸들링 안되는 이슈 수정

### DIFF
--- a/app/admin/components/CategoryItem.tsx
+++ b/app/admin/components/CategoryItem.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import styles from "./CategoryItem.module.scss";
 import useModalStore from "@/stores/modalStore";
+import { useToastStore } from "@/stores/toastStore";
 
 type CategoryItemProps = {
     id: number;
@@ -20,6 +21,7 @@ export default function CategoryItem({
     handleUpdate,
 }: CategoryItemProps) {
     const { openModal } = useModalStore();
+    const { show } = useToastStore();
     const handleEditClick = () => {
         openModal("category", {
             type: "edit",

--- a/hooks/useAdminCategories.ts
+++ b/hooks/useAdminCategories.ts
@@ -1,3 +1,4 @@
+import { useToastStore } from "@/stores/toastStore";
 import { fetcher } from "@/utils/fetcher";
 import useSWR, { mutate } from "swr";
 
@@ -14,6 +15,7 @@ export type ResponseType = {
 };
 
 export const useAdminCategories = (currentPage: number) => {
+    const { show } = useToastStore();
     const getUrl = `/api/admin/categories?currentPage=${currentPage}`;
 
     const { data, error, isLoading } = useSWR<ResponseType>(getUrl, fetcher, {
@@ -21,26 +23,46 @@ export const useAdminCategories = (currentPage: number) => {
     });
 
     const createCategory = async (name: string) => {
-        await fetcher("/api/admin/categories", {
-            method: "POST",
-            body: { name },
-        });
-        mutate(getUrl);
+        try {
+            await fetcher("/api/admin/categories", {
+                method: "POST",
+                body: { name },
+            });
+            mutate(getUrl);
+        } catch (error) {
+            if (error instanceof Error) {
+                show(error.message);
+            }
+        }
     };
 
     const updateCategory = async (id: number, name: string) => {
-        await fetcher(`/api/admin/categories/${id}`, {
-            method: "PATCH",
-            body: { name },
-        });
-        mutate(getUrl);
+        try {
+            await fetcher(`/api/admin/categories/${id}`, {
+                method: "PATCH",
+                body: { name },
+            });
+            show("카테고리 이름이 수정되었습니다.");
+            mutate(getUrl);
+        } catch (error) {
+            if (error instanceof Error) {
+                show(error.message);
+            }
+        }
     };
 
     const deleteCategory = async (id: number) => {
-        await fetcher(`/api/admin/categories/${id}`, {
-            method: "DELETE",
-        });
-        mutate(getUrl);
+        try {
+            await fetcher(`/api/admin/categories/${id}`, {
+                method: "DELETE",
+            });
+            show("카테고리가 삭제되었습니다.");
+            mutate(getUrl);
+        } catch (error) {
+            if (error instanceof Error) {
+                show(error.message);
+            }
+        }
     };
 
     return {

--- a/infra/repositories/supabase/SbCategoryRepository.ts
+++ b/infra/repositories/supabase/SbCategoryRepository.ts
@@ -116,6 +116,9 @@ export class SbCategoryRepository implements CategoryRepository {
             .single();
 
         if (error) {
+            if (error.code === "23505") {
+                throw new Error(`이미 존재하는 카테고리입니다.`);
+            }
             throw new Error(`카테고리 수정 실패: ${error.message}`);
         }
     }

--- a/utils/fetcher.ts
+++ b/utils/fetcher.ts
@@ -39,7 +39,7 @@ export async function fetcher<T>(
     }
 
     if (!response.ok) {
-        throw new Error("잠시 후에 다시 시도해주세요.");
+        throw new Error(data.message || "잠시 후에 다시 시도해주세요.");
     }
 
     return data;


### PR DESCRIPTION
## 작업 내용
- 카테고리 등록(수정) 시 기존 카테고리 이름과 겹치면 핸들링 안 되는 이슈 수정
  - 토스트 뜨도록 수정
  - 수정, 삭제 완료 후에도 토스트 메시지 출력

closes #272
